### PR TITLE
feature (constructor signatures)

### DIFF
--- a/src/JDNConvertibleCalendar.ts
+++ b/src/JDNConvertibleCalendar.ts
@@ -69,7 +69,7 @@ export module JDNConvertibleCalendarModule {
          * @param month month of the given date.
          * @param day day of the given date (day of month, 1 based index).
          * @param dayOfWeek day of week of the given date (0 based index), if any.
-         * @param daytime time of the day (0 - 0.9…), if any. 0 refers to midnight, 0.5 to noon, 0.9… to midnigh of the same day. 1 would already refer to the next day and is thus not valid.
+         * @param daytime time of the day (0 - 0.9…), if any. 0 refers to midnight, 0.5 to noon, 0.9… to midnight of the same day. 1 would already refer to the next day and is thus not valid.
          */
         constructor(public readonly year: number, public readonly month: number, public readonly day: number, public readonly dayOfWeek?: number, public readonly daytime?: number) {
 

--- a/src/JDNConvertibleCalendar.ts
+++ b/src/JDNConvertibleCalendar.ts
@@ -300,10 +300,25 @@ export module JDNConvertibleCalendarModule {
         /**
          * This constructor is inherited by all subclasses (no implementation in subclass required).
          *
-         * @param {JDNConvertibleCalendarModule.JDNPeriod} jdnPeriod JDN period to create a calendar specific date from.
          */
-        constructor(jdnPeriod: JDNPeriod) {
-            this.convertJDNPeriodToCalendarPeriod(jdnPeriod);
+        constructor(period: JDNPeriod);
+        constructor(period: CalendarPeriod);
+        constructor(period: any) {
+
+            if (period instanceof JDNPeriod) {
+                // period is a JDNPeriod
+
+                this.convertJDNPeriodToCalendarPeriod(period);
+            } else {
+                // period is a CalendarPeriod
+
+                let jdnStart = this.calendarToJDN(period.periodStart);
+                let jdnEnd = this.calendarToJDN(period.periodEnd);
+
+                this.convertJDNPeriodToCalendarPeriod(new JDNPeriod(jdnStart, jdnEnd));
+            }
+
+
         }
 
         /**

--- a/src/JDNConvertibleCalendar.ts
+++ b/src/JDNConvertibleCalendar.ts
@@ -309,6 +309,9 @@ export module JDNConvertibleCalendarModule {
         /**
          * This constructor is inherited by all subclasses (no implementation in subclass required).
          *
+         * The constructor supports two signatures:
+         * - period: JDNPeriod creates a date from the given `JDNPeriod` (two JDNs)
+         * - period: CalendarPeriod creates a date from the given `CalendarPeriod` (two calendar dates)
          */
         constructor(period: JDNPeriod);
         constructor(period: CalendarPeriod);
@@ -329,7 +332,6 @@ export module JDNConvertibleCalendarModule {
 
             if (period instanceof JDNPeriod) {
                 // period is a JDNPeriod
-
                 this.convertJDNPeriodToCalendarPeriod(period);
             } else {
                 // period is a CalendarPeriod

--- a/test/UnitTests.ts
+++ b/test/UnitTests.ts
@@ -866,7 +866,7 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
 
     describe('Instantiate a calendar date from a calendar period', () => {
 
-        it('create a Gregorian date from a calendar period', () => {
+        it('create a Gregorian date from an exact calendar period', () => {
 
             const gregorianCalendarDate: GregorianCalendarDate = new GregorianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 26)));
 
@@ -875,10 +875,30 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
             checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodStart, false);
             checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodEnd, false);
 
+            const jdnPeriod = gregorianCalendarDate.toJDNPeriod();
+
+            checkJDN(2458326, jdnPeriod.periodStart);
+            checkJDN(2458326, jdnPeriod.periodEnd);
 
         });
 
         it('create a Gregorian date from a calendar period', () => {
+
+            const gregorianCalendarDate: GregorianCalendarDate = new GregorianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 27)));
+
+            const calPeriod = gregorianCalendarDate.toCalendarPeriod();
+
+            checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodStart, false);
+            checkCalendarDate(new CalendarDate(2018, 7, 27), calPeriod.periodEnd, false);
+
+            const jdnPeriod = gregorianCalendarDate.toJDNPeriod();
+
+            checkJDN(2458326, jdnPeriod.periodStart);
+            checkJDN(2458327, jdnPeriod.periodEnd);
+
+        });
+
+        it('create a Gregorian date from an exact calendar period', () => {
 
             const julianCalendarDate: JulianCalendarDate = new JulianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 26)));
 
@@ -886,6 +906,27 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
 
             checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodStart, false);
             checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodEnd, false);
+
+            const jdnPeriod = julianCalendarDate.toJDNPeriod();
+
+            checkJDN(2458339, jdnPeriod.periodStart);
+            checkJDN(2458339, jdnPeriod.periodEnd);
+
+        });
+
+        it('create a Gregorian date from a calendar period', () => {
+
+            const julianCalendarDate: JulianCalendarDate = new JulianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 27)));
+
+            const calPeriod = julianCalendarDate.toCalendarPeriod();
+
+            checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodStart, false);
+            checkCalendarDate(new CalendarDate(2018, 7, 27), calPeriod.periodEnd, false);
+
+            const jdnPeriod = julianCalendarDate.toJDNPeriod();
+
+            checkJDN(2458339, jdnPeriod.periodStart);
+            checkJDN(2458340, jdnPeriod.periodEnd);
 
         });
 

--- a/test/UnitTests.ts
+++ b/test/UnitTests.ts
@@ -1500,7 +1500,7 @@ describe('Instantiate a calendar date from a calendar period', () => {
 
     });
 
-    it('create a Gregorian date from an exact calendar period', () => {
+    it('create a Julian date from an exact calendar period', () => {
 
         const julianCalendarDate: JulianCalendarDate = new JulianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 26)));
 
@@ -1516,7 +1516,7 @@ describe('Instantiate a calendar date from a calendar period', () => {
 
     });
 
-    it('create a Gregorian date from a calendar period', () => {
+    it('create a Julian date from a calendar period', () => {
 
         const julianCalendarDate: JulianCalendarDate = new JulianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 27)));
 

--- a/test/UnitTests.ts
+++ b/test/UnitTests.ts
@@ -26,14 +26,17 @@ let assert = require('assert');
  *
  * @param {CalendarDate} expected expected calendar date.
  * @param {CalendarDate} received received calendar date.
+ * @param checkDayOfWeek indicates if week day should be checked.
  */
-const checkCalendarDate = (expected: CalendarDate, received: CalendarDate) => {
+const checkCalendarDate = (expected: CalendarDate, received: CalendarDate, checkDayOfWeek: Boolean = true) => {
 
     assert.strictEqual(received.year, expected.year, `calendar date is wrong: year is ${received.year} instead of ${expected.year}`);
     assert.strictEqual(received.month, expected.month, `calendar date is wrong: month is ${received.month} instead of ${expected.month}`);
     assert.strictEqual(received.day, expected.day, `calendar date is wrong: day is ${received.day} instead of ${expected.day}`);
-    assert.strictEqual(received.dayOfWeek, expected.dayOfWeek, `calendar date is wrong: day of week is ${received.dayOfWeek} instead of ${expected.dayOfWeek}`);
 
+    if (checkDayOfWeek) {
+        assert.strictEqual(received.dayOfWeek, expected.dayOfWeek, `calendar date is wrong: day of week is ${received.dayOfWeek} instead of ${expected.dayOfWeek}`);
+    }
 };
 
 /**
@@ -860,6 +863,33 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
 
     });
 
+
+    describe('Instantiate a calendar date from a calendar period', () => {
+
+        it('create a Gregorian date from a calendar period', () => {
+
+            const gregorianCalendarDate: GregorianCalendarDate = new GregorianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 26)));
+
+            const calPeriod = gregorianCalendarDate.toCalendarPeriod();
+
+            checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodStart, false);
+            checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodEnd, false);
+
+
+        });
+
+        it('create a Gregorian date from a calendar period', () => {
+
+            const julianCalendarDate: JulianCalendarDate = new JulianCalendarDate(new CalendarPeriod(new CalendarDate(2018, 7, 26), new CalendarDate(2018, 7, 26)));
+
+            const calPeriod = julianCalendarDate.toCalendarPeriod();
+
+            checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodStart, false);
+            checkCalendarDate(new CalendarDate(2018, 7, 26), calPeriod.periodEnd, false);
+
+        });
+
+    });
 
 
 });


### PR DESCRIPTION
This PR provides different signatures for the constructor so a calendar date can be instantiated from a JDN period or a calendar date period.

see https://www.typescriptlang.org/docs/handbook/functions.html#overloads