### PR TITLE
Change build (DSP-790)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 language: node_js
 
 node_js:
-  - "8"
+  - "12"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,4 @@ cache:
   directories:
     - "node_modules"
 
-before_script:
-- npm install -g typescript
-
 script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ node_js:
 
 cache:
   directories:
-    - "node_modules"
+    - node_modules
 
 script: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "jdnconvertiblecalendar",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -11,15 +17,15 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.48",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
+      "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.42.tgz",
-      "integrity": "sha512-8LCqostMfYwQs9by1k21/P4KZp9uFQk3Q528y3qtPKQnCJmKz0Em3YzgeNjTNV1FVrG/7n/6j12d4UKg9zSgDw==",
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
+      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
       "dev": true
     },
     "@types/strip-bom": {
@@ -34,6 +40,18 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -43,6 +61,43 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
+    "array.prototype.map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.4"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -50,12 +105,24 @@
       "dev": true
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
       "dev": true,
       "requires": {
-        "util": "0.10.3"
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
       }
     },
     "backbone": {
@@ -73,6 +140,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -83,16 +156,31 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "chalk": {
@@ -123,6 +211,61 @@
         }
       }
     },
+    "chokidar": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -138,12 +281,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -151,12 +288,27 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
       }
     },
     "diff": {
@@ -165,10 +317,119 @@
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "dev": true,
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "fs-extra": {
@@ -188,6 +449,25 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -202,6 +482,15 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -209,33 +498,49 @@
       "dev": true
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "highlight.js": {
@@ -275,11 +580,178 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
-    "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
       "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
+      "dev": true
+    },
+    "is-nan": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.0.tgz",
+      "integrity": "sha512-z7bbREymOqt2CCaZVly8aC4ML3Xhfi0ekuOnjO2L8vKdl+CttdVoGZQhd4adMFAsxQ5VeRVwORs4tU8RH+HFtQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "iterate-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
+      "dev": true
+    },
+    "iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "dev": true,
+      "requires": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
+      }
+    },
+    "jquery": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -290,11 +762,66 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "lunr": {
       "version": "2.3.6",
@@ -324,49 +851,146 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
+      "integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.3.1",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.4.2",
+        "debug": "4.1.1",
+        "diff": "4.0.2",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.2",
+        "object.assign": "4.1.0",
+        "promise.allsettled": "1.0.2",
+        "serialize-javascript": "4.0.0",
+        "strip-json-comments": "3.0.1",
+        "supports-color": "7.1.0",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.0.0",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -377,20 +1001,40 @@
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+    "p-limit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+      "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "p-try": "^2.0.0"
       }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
@@ -405,11 +1049,48 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise.allsettled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+      "dev": true,
+      "requires": {
+        "array.prototype.map": "^1.0.1",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "iterate-value": "^1.0.0"
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
@@ -420,6 +1101,18 @@
         "resolve": "^1.1.6"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -428,6 +1121,27 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.3",
@@ -456,6 +1170,51 @@
         "source-map": "^0.6.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -469,12 +1228,21 @@
       "dev": true
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^4.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "ts-node": {
@@ -496,9 +1264,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -532,6 +1300,14 @@
         "shelljs": "^0.8.3",
         "typedoc-default-themes": "^0.6.0",
         "typescript": "3.5.x"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -547,30 +1323,17 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
+      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
+      "optional": true
     },
     "underscore": {
       "version": "1.9.1",
@@ -585,12 +1348,25 @@
       "dev": true
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        }
       }
     },
     "v8flags": {
@@ -602,17 +1378,318 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "workerpool": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
+      "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+      "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "decamelize": "^1.2.0",
+        "flat": "^4.1.0",
+        "is-plain-obj": "^1.1.0",
+        "yargs": "^14.2.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "yn": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
-    },
     "@types/mocha": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
@@ -116,6 +110,12 @@
         "util": "^0.12.0"
       }
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
@@ -123,15 +123,6 @@
       "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
-      }
-    },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dev": true,
-      "requires": {
-        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -281,6 +272,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -312,9 +309,9 @@
       }
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "emoji-regex": {
@@ -433,14 +430,15 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "requires": {
+        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -469,9 +467,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -492,9 +490,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "growl": {
@@ -504,9 +502,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -543,12 +541,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "9.15.9",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
-      "integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
-      "dev": true
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -575,9 +567,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "is-arguments": {
@@ -606,6 +598,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
       "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -737,12 +738,6 @@
         "iterate-iterator": "^1.0.1"
       }
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
-      "dev": true
-    },
     "js-yaml": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
@@ -754,12 +749,13 @@
       }
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "locate-path": {
@@ -772,9 +768,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "log-symbols": {
@@ -823,10 +819,19 @@
         }
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "lunr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
-      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
     "make-error": {
@@ -836,9 +841,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
       "dev": true
     },
     "minimatch": {
@@ -1001,6 +1006,15 @@
         "wrappy": "1"
       }
     },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
+    },
     "p-limit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
@@ -1114,11 +1128,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -1144,14 +1159,24 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "shiki": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
+      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
       }
     },
     "source-map": {
@@ -1284,43 +1309,29 @@
       }
     },
     "typedoc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
-      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
+      "version": "0.20.32",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.32.tgz",
+      "integrity": "sha512-GSopd/tiqoKE3fEdvhoaEpR9yrEPsR9tknAjkoeSPL6p1Rq5aVsKxBhhF6cwoDJ7oWjpvnm8vs0rQN0BxEHuWQ==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.3",
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.1.2",
-        "highlight.js": "^9.15.8",
-        "lodash": "^4.17.15",
-        "marked": "^0.7.0",
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
+        "marked": "^2.0.1",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.0",
-        "typescript": "3.5.x"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-          "dev": true
-        }
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.3",
+        "typedoc-default-themes": "^0.12.9"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
-      "integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
-      "dev": true,
-      "requires": {
-        "backbone": "^1.4.0",
-        "jquery": "^3.4.1",
-        "lunr": "^2.3.6",
-        "underscore": "^1.9.1"
-      }
+      "version": "0.12.9",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.9.tgz",
+      "integrity": "sha512-Jd5fYTiqzinZdoIY382W7tQXTwAzWRdg8KbHfaxmb78m1/3jL9riXtk23oBOKwhi8GFVykCOdPzEJKY87/D0LQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.0.2",
@@ -1329,22 +1340,16 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
-      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-EWhx3fHy3M9JbaeTnO+rEqzCe1wtyQClv6q3YWq0voOj4E+bMZBErVS1GAHPDiRGONYq34M1/d8KuQMgvi6Gjw==",
       "dev": true,
       "optional": true
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-      "dev": true
-    },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "util": {
@@ -1377,6 +1382,12 @@
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",
@@ -1477,6 +1488,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "tsc",
     "test": "tsc && ./node_modules/mocha/bin/mocha --require esm ./dist/test/conversions.js && ./node_modules/mocha/bin/mocha --require esm ./dist/test/names.js",
     "yalc-publish": "tsc && yalc publish --push",
-    "builddocs": "typedoc --out docs --readme none --name 'JDNConvertibleCalendar API Documentation' --module commonjs src/*.ts"
+    "builddocs": "typedoc --readme none --name 'JDNConvertibleCalendar API Documentation' --excludeExternals true src/index.ts"
   },
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "esm": "^3.2.25",
     "mocha": "^8.1.3",
     "ts-node": "^4.0.2",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.20.32",
     "typescript": "4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepublishOnly": "npm run prepare",
     "prepare": "tsc",
     "test": "tsc && ./node_modules/mocha/bin/mocha --require esm ./dist/test/conversions.js && ./node_modules/mocha/bin/mocha --require esm ./dist/test/names.js",
+    "yalc-publish": "tsc && yalc publish --push",
     "builddocs": "typedoc --out docs --readme none --name 'JDNConvertibleCalendar API Documentation' --module commonjs src/*.ts"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepublishOnly": "npm run prepare",
     "prepare": "tsc",
-    "test": "tsc && ./node_modules/mocha/bin/mocha ./dist/test/conversions.js && ./node_modules/mocha/bin/mocha ./dist/test/names.js",
+    "test": "tsc && ./node_modules/mocha/bin/mocha --require esm ./dist/test/conversions.js && ./node_modules/mocha/bin/mocha --require esm ./dist/test/names.js",
     "builddocs": "typedoc --out docs --readme none --name 'JDNConvertibleCalendar API Documentation' --module commonjs src/*.ts"
   },
   "repository": {
@@ -28,12 +28,13 @@
   },
   "homepage": "https://github.com/dhlab-basel/JDNConvertibleCalendar#readme",
   "devDependencies": {
-    "@types/mocha": "^2.2.48",
-    "@types/node": "^8.0.56",
-    "assert": "^1.4.1",
-    "mocha": "^4.0.1",
+    "@types/mocha": "^8.0.3",
+    "@types/node": "^14.6.4",
+    "assert": "^2.0.0",
+    "esm": "^3.2.25",
+    "mocha": "^8.1.3",
     "ts-node": "^4.0.2",
     "typedoc": "^0.15.0",
-    "typescript": "3.5.3"
+    "typescript": "4.0.2"
   }
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,7 @@
+# Release Notes
+
+## Releases
+
 - v0.0.1: initial version with conversion formulae from fourmilab.ch
 
 - v0.0.2: conversion formulae rewritten (consistent handling of year 0), added more extensive tests (<https://github.com/dhlab-basel/JDNConvertibleCalendar/pull/4>)
@@ -7,3 +11,8 @@
 - v0.0.4: provide implementation for the Islamic calendar (https://github.com/dhlab-basel/JDNConvertibleCalendar/pull/10)
 
 - v0.0.5: provide names for weekdays and months
+
+## Publish to npm
+
+From the project root, run `npm publish --dry-run`.
+If everything looks good, omit the dry run flag.

--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -1,3 +1,23 @@
+/*
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of JDNConvertibleCalendar.
+ *
+ * JDNConvertibleCalendar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JDNConvertibleCalendar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { JDNConvertibleCalendarError } from './JDNConvertibleCalendarError';
 import { Utils } from './Utils';
 

--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -1,0 +1,35 @@
+import { JDNConvertibleCalendarError } from './JDNConvertibleCalendarError';
+import { Utils } from './Utils';
+
+/**
+ * Represents a calendar date (calendar agnostic).
+ *
+ * Assumes that every supported calendar
+ * can be represented by a combination of year, month, and day.
+ *
+ */
+export class CalendarDate {
+
+    /**
+     *
+     * Please note that this software uses the (astronomical) convention that BCE dates are represented as negative years and that the year zero (0) is used.
+     * The year 1 BCE must be indicated as year 0, and the year 2 BCE corresponds to -1 etc.
+     *
+     * @param year year of the given date.
+     * @param month month of the given date.
+     * @param day day of the given date (day of month, 1 based index).
+     * @param dayOfWeek day of week of the given date (0 based index), if any.
+     * @param daytime time of the day (0 - 0.9…), if any. 0 refers to midnight, 0.5 to noon, 0.9… to midnight of the same day. 1 would already refer to the next day and is thus not valid.
+     */
+    constructor(public readonly year: number, public readonly month: number, public readonly day: number, public readonly dayOfWeek?: number, public readonly daytime?: number) {
+
+
+        // check validity of daytime
+        if (daytime !== undefined && daytime >= 1) throw new JDNConvertibleCalendarError('Invalid daytime: ' + daytime + ', valid range: 0 - 0.9…');
+
+        // TODO: When other calendar than Gregorian or Julian are implemented, this may have to be changed
+        if (dayOfWeek !== undefined && (!Utils.isInteger(dayOfWeek) || dayOfWeek < 0 || dayOfWeek > 6)) throw new JDNConvertibleCalendarError('Invalid day of week: ' + dayOfWeek)
+
+    }
+
+}

--- a/src/CalendarPeriod.ts
+++ b/src/CalendarPeriod.ts
@@ -1,0 +1,19 @@
+/**
+ * Represents a period as two calendar dates.
+ */
+import { CalendarDate } from './CalendarDate';
+
+export class CalendarPeriod {
+
+    /**
+     *
+     * @param periodStart start of the period.
+     * @param periodEnd End of the period.
+     */
+    constructor(public readonly periodStart: CalendarDate, public readonly periodEnd: CalendarDate) {
+
+        // TODO: can we check that periodStart equals or is before periodEnd?
+
+    }
+
+}

--- a/src/CalendarPeriod.ts
+++ b/src/CalendarPeriod.ts
@@ -1,3 +1,23 @@
+/*
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of JDNConvertibleCalendar.
+ *
+ * JDNConvertibleCalendar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JDNConvertibleCalendar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 /**
  * Represents a period as two calendar dates.
  */

--- a/src/JDNCalendarConversion.ts
+++ b/src/JDNCalendarConversion.ts
@@ -17,11 +17,8 @@
  * You should have received a copy of the GNU Affero General Public
  * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import {JDNConvertibleCalendarModule} from "./JDNConvertibleCalendar";
 import {TypeDefinitionsModule} from './TypeDefinitions';
-import JDC = TypeDefinitionsModule.JDC;
-import JDN = TypeDefinitionsModule.JDN;
+import { CalendarDate } from './CalendarDate';
 
 export module JDNConvertibleConversionModule {
 
@@ -50,7 +47,7 @@ export module JDNConvertibleConversionModule {
      * @param calendarDate Gregorian calendar date to be converted to JDC.
      * @returns the JDC representing the given Gregorian calendar date.
      */
-    export const gregorianToJDC = (calendarDate: JDNConvertibleCalendarModule.CalendarDate): JDC => {
+    export const gregorianToJDC = (calendarDate: CalendarDate): TypeDefinitionsModule.JDC => {
 
         // TODO: check validity of given calendar date
 
@@ -95,8 +92,8 @@ export module JDNConvertibleConversionModule {
      * @param calendarDate Gregorian calendar date to be converted to JDN.
      * @returns the JDN representing the given Gregorian calendar date.
      */
-    export const gregorianToJDN = (calendarDate: JDNConvertibleCalendarModule.CalendarDate): JDN => {
-        const jdc: JDC = gregorianToJDC(calendarDate);
+    export const gregorianToJDN = (calendarDate: CalendarDate): TypeDefinitionsModule.JDN => {
+        const jdc: TypeDefinitionsModule.JDC = gregorianToJDC(calendarDate);
 
         /*
 
@@ -121,7 +118,7 @@ export module JDNConvertibleConversionModule {
      * @param jdc JDC to be converted to a Gregorian calendar date.
      * @returns the Gregorian calendar date created from the given JDC.
      */
-    export const JDCToGregorian = (jdc: JDC): JDNConvertibleCalendarModule.CalendarDate => {
+    export const JDCToGregorian = (jdc: TypeDefinitionsModule.JDC): CalendarDate => {
         jdc = jdc + 0.5;
         const z = truncateDecimals(jdc);
         const f = jdc - z;
@@ -152,7 +149,7 @@ export module JDNConvertibleConversionModule {
 
         let fullday = truncateDecimals(day);
         let daytime = day - fullday;
-        return new JDNConvertibleCalendarModule.CalendarDate(year, month, fullday, undefined, daytime);
+        return new CalendarDate(year, month, fullday, undefined, daytime);
     };
 
     /**
@@ -161,7 +158,7 @@ export module JDNConvertibleConversionModule {
      * @param jdn the given JDN.
      * @returns the Gregorian calendar date created from the given JDN.
      */
-    export const JDNToGregorian = (jdn: JDN): JDNConvertibleCalendarModule.CalendarDate => {
+    export const JDNToGregorian = (jdn: TypeDefinitionsModule.JDN): CalendarDate => {
        return JDCToGregorian(jdn);
     };
 
@@ -176,7 +173,7 @@ export module JDNConvertibleConversionModule {
      * @param calendarDate Julian calendar date to be converted to JDC.
      * @returns JDC representing the given Julian calendar date.
      */
-    export const julianToJDC = (calendarDate: JDNConvertibleCalendarModule.CalendarDate): JDC => {
+    export const julianToJDC = (calendarDate: CalendarDate): TypeDefinitionsModule.JDC => {
 
         // TODO: check validity of given calendar date
 
@@ -214,7 +211,7 @@ export module JDNConvertibleConversionModule {
      * @param calendarDate Julian calendar date to be converted to JDN.
      * @returns JDN representing the given Julian calendar date.
      */
-    export const julianToJDN = (calendarDate: JDNConvertibleCalendarModule.CalendarDate): JDN => {
+    export const julianToJDN = (calendarDate: CalendarDate): TypeDefinitionsModule.JDN => {
 
         // TODO: check validity of given calendar date
         const jdc = julianToJDC(calendarDate);
@@ -241,7 +238,7 @@ export module JDNConvertibleConversionModule {
      * @param jdc JDC to be converted to a Julian calendar date.
      * @returns Julian calendar date created from given JDC.
      */
-    export const JDCToJulian = (jdc: JDC): JDNConvertibleCalendarModule.CalendarDate => {
+    export const JDCToJulian = (jdc: TypeDefinitionsModule.JDC): CalendarDate => {
         jdc = jdc + 0.5;
         const z = truncateDecimals(jdc);
         const f = jdc - z;
@@ -269,7 +266,7 @@ export module JDNConvertibleConversionModule {
 
         let fullday = truncateDecimals(day);
         let daytime = day - fullday;
-        return new JDNConvertibleCalendarModule.CalendarDate(year, month, fullday, undefined, daytime);
+        return new CalendarDate(year, month, fullday, undefined, daytime);
     };
 
     /**
@@ -278,7 +275,7 @@ export module JDNConvertibleConversionModule {
      * @param jdn JDN to be converted to a Julian calendar date.
      * @returns Julian calendar date created from given JDN.
      */
-    export const JDNToJulian = (jdn: JDN): JDNConvertibleCalendarModule.CalendarDate => {
+    export const JDNToJulian = (jdn: TypeDefinitionsModule.JDN): CalendarDate => {
         return JDCToJulian(jdn);
     };
 
@@ -292,7 +289,7 @@ export module JDNConvertibleConversionModule {
      * @param jdc given JDC.
      * @returns the number of the day of the week for the given JDC (0 Sunday, 1 Monday, 2 Tuesday, 3 Wednesday, 4 Thursday, 5 Friday, 6 Saturday).
      */
-    export const dayOfWeekFromJDC = (jdc: JDC) => {
+    export const dayOfWeekFromJDC = (jdc: TypeDefinitionsModule.JDC) => {
         return truncateDecimals(jdc + 1.5) %  7;
     };
 
@@ -319,7 +316,7 @@ export module JDNConvertibleConversionModule {
      * @param calendarDate Islamic calendar date to be converted to JDC.
      * @returns JDC representing the given Islamic calendar date.
      */
-    export const islamicToJDC = (calendarDate: JDNConvertibleCalendarModule.CalendarDate): JDC => {
+    export const islamicToJDC = (calendarDate: CalendarDate): TypeDefinitionsModule.JDC => {
 
         const h = calendarDate.year;
         const m = calendarDate.month;
@@ -367,7 +364,7 @@ export module JDNConvertibleConversionModule {
      * @param calendarDate Islamic calendar date to be converted to JDN.
      * @returns JDN representing the given Islamic calendar date.
      */
-    export const islamicToJDN = (calendarDate: JDNConvertibleCalendarModule.CalendarDate): JDN => {
+    export const islamicToJDN = (calendarDate: CalendarDate): TypeDefinitionsModule.JDN => {
         const jdc = islamicToJDC(calendarDate);
 
         return truncateDecimals(jdc + 0.5); // adaption because full number without fraction of JDC represents noon.
@@ -396,10 +393,10 @@ export module JDNConvertibleConversionModule {
      * @param jdc JDC to be converted to an Islamic calendar date.
      * @returns Islamic calendar date created from given JDC.
      */
-    export const JDCToIslamic = (jdc: JDC): JDNConvertibleCalendarModule.CalendarDate => {
+    export const JDCToIslamic = (jdc: TypeDefinitionsModule.JDC): CalendarDate => {
 
         // convert given JDC into a Julian calendar date
-        const julianCalendarDate: JDNConvertibleCalendarModule.CalendarDate = JDCToJulian(jdc);
+        const julianCalendarDate: CalendarDate = JDCToJulian(jdc);
 
         const x = julianCalendarDate.year;
         let m = julianCalendarDate.month;
@@ -475,7 +472,7 @@ export module JDNConvertibleConversionModule {
             d= 30;
         }
 
-        return new JDNConvertibleCalendarModule.CalendarDate(h, m, d, undefined, julianCalendarDate.daytime);
+        return new CalendarDate(h, m, d, undefined, julianCalendarDate.daytime);
     };
 
     /**
@@ -484,7 +481,7 @@ export module JDNConvertibleConversionModule {
      * @param jdn JDN to be converted to an Islamic calendar date.
      * @returns @returns Islamic calendar date created from given JDN.
      */
-    export const JDNToIslamic = (jdn: JDN): JDNConvertibleCalendarModule.CalendarDate => {
+    export const JDNToIslamic = (jdn: TypeDefinitionsModule.JDN): CalendarDate => {
         return JDCToIslamic(jdn);
     }
 }

--- a/src/JDNCalendarConversion.ts
+++ b/src/JDNCalendarConversion.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
  * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
  *
  * This file is part of JDNConvertibleCalendar.

--- a/src/JDNCalendarNames.ts
+++ b/src/JDNCalendarNames.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
  * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
  *
  * This file is part of JDNConvertibleCalendar.

--- a/src/JDNConvertibleCalendar.ts
+++ b/src/JDNConvertibleCalendar.ts
@@ -18,718 +18,612 @@
  * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {JDNConvertibleConversionModule} from './JDNCalendarConversion';
-import {TypeDefinitionsModule} from './TypeDefinitions';
-import JDN = TypeDefinitionsModule.JDN;
+import { JDNConvertibleConversionModule } from './JDNCalendarConversion';
+import { TypeDefinitionsModule } from './TypeDefinitions';
+import { CalendarDate } from './CalendarDate';
+import { JDNPeriod } from './JDNPeriod';
+import { CalendarPeriod } from './CalendarPeriod';
+import { JDNConvertibleCalendarError } from './JDNConvertibleCalendarError';
+import { Utils } from './Utils';
 
-export module JDNConvertibleCalendarModule {
 
+/**
+ * Abstract class representing any calendar
+ * that can be converted from and to a Julian Day.
+ */
+export abstract class JDNConvertibleCalendar {
 
     /**
-     * Checks if a given number is an integer.
+     * Constant for the Gregorian calendar.
+     */
+    protected static readonly gregorian = 'Gregorian';
+
+    /**
+     * Constant for the Julian calendar.
+     */
+    protected static readonly julian = 'Julian';
+
+    /**
+     * Constant for the Islamic calendar.
+     */
+    protected static readonly islamic = 'Islamic';
+
+    /**
+     * Supported calendars (to be extended when new subclasses are implemented).
+     */
+    public static readonly supportedCalendars = [JDNConvertibleCalendar.gregorian, JDNConvertibleCalendar.julian, JDNConvertibleCalendar.islamic];
+
+    /**
+     * Calendar name of a subclass of `JDNConvertibleCalendar`.
+     */
+    public abstract readonly calendarName: string;
+
+    /**
+     * Indicates how many months a year has in a specific calendar.
+     */
+    public abstract readonly monthsInYear: number;
+
+    /**
+     * Indicates if the year 0 exists in a specific calendar.
+     */
+    public abstract readonly yearZeroExists: Boolean;
+
+    //
+    // Both calendar dates and JDNs are stored in parallel to avoid unnecessary conversions (JDN to calendar date and possibly back to JDN).
+    // Manipulations are exclusively performed by `this.convertJDNPeriodToCalendarPeriod` that keeps them in sync.
+    //
+
+    /**
+     * Start of a given date in a specific calendar.
+     */
+    protected calendarStart: CalendarDate;
+
+    /**
+     * End of a given date in a specific calendar.
+     */
+    protected calendarEnd: CalendarDate;
+
+    /**
+     * Indicates if the date is exact (start and end of the given period are equal).
+     */
+    protected exactDate: Boolean;
+
+    /**
+     * Start of given date as JDN.
+     */
+    protected jdnStart: TypeDefinitionsModule.JDN;
+
+    /**
+     * End of given date as JDN.
+     */
+    protected jdnEnd: TypeDefinitionsModule.JDN;
+
+    /**
+     * Converts a given JDN to a calendar date.
+     * This method has to be implemented for each subclass
+     * (specific calendar).
      *
-     * @param num number to check for.
-     * @returns true if the given number is an integer, returns false otherwise.
-     */
-    const isInteger = (num: number): boolean => {
-
-        // https://stackoverflow.com/questions/3885817/how-do-i-check-that-a-number-is-float-or-integer
-        return num % 1 === 0;
-    };
-
-    /**
-     * Represents an error that occurred when using `JDNConvertibleCalendarModule`.
-     */
-    export class JDNConvertibleCalendarError extends Error {
-
-        /**
-         *
-         * @param message description of the error.
-         */
-        constructor(message: string) {
-            super(message);
-        }
-    }
-
-    /**
-     * Represents a calendar date (calendar agnostic).
+     * Attention: depending on the conventions used, there may be a year 0 or not.
+     * This depends on the implementation of this conversion function.
      *
-     * Assumes that every supported calendar
-     * can be represented by a combination of year, month, and day.
+     * @param jdn JDN to be converted to a calendar date.
+     * @returns calendar date created from given JDN.
+     */
+    protected abstract JDNToCalendar(jdn: TypeDefinitionsModule.JDN): CalendarDate;
+
+    /**
+     * Converts a given calendar date to JDN.
+     * This method has to be implemented for each subclass
+     * (specific calendar).
      *
+     * Attention: depending on the conventions used, there may be a year 0 or not.
+     * This depends on the implementation of this conversion function.
+     *
+     * @param date calendar date to be converted to a JDN.
+     * @returns JDN created from given calendar date.
      */
-    export class CalendarDate {
+    protected abstract calendarToJDN(date: CalendarDate):TypeDefinitionsModule.JDN;
 
-        /**
-         *
-         * Please note that this software uses the (astronomical) convention that BCE dates are represented as negative years and that the year zero (0) is used.
-         * The year 1 BCE must be indicated as year 0, and the year 2 BCE corresponds to -1 etc.
-         *
-         * @param year year of the given date.
-         * @param month month of the given date.
-         * @param day day of the given date (day of month, 1 based index).
-         * @param dayOfWeek day of week of the given date (0 based index), if any.
-         * @param daytime time of the day (0 - 0.9…), if any. 0 refers to midnight, 0.5 to noon, 0.9… to midnight of the same day. 1 would already refer to the next day and is thus not valid.
-         */
-        constructor(public readonly year: number, public readonly month: number, public readonly day: number, public readonly dayOfWeek?: number, public readonly daytime?: number) {
+    /**
+     * Calculates the day of week of a given JDN.
+     *
+     * @param jdn JDN for which the day of the week is to be calculated.
+     * @returns day of week of the given JDN (as a 0-based index).
+     */
+    protected abstract dayOfWeekFromJDN(jdn: TypeDefinitionsModule.JDN): number;
 
+    /**
+     * Calculates number of days for the month of the given date.
+     *
+     * The given date is expected to be of the same calendar as the instance the method is called on.
+     *
+     * @param date given date.
+     * @returns number of days in month of given date.
+     */
+    public daysInMonth(date: CalendarDate): number {
 
-            // check validity of daytime
-            if (daytime !== undefined && daytime >= 1) throw new JDNConvertibleCalendarError('Invalid daytime: ' + daytime + ', valid range: 0 - 0.9…');
+        // get JDN for first day of the month of the given calendar date
+        const firstDayOfGivenMonth = this.calendarToJDN(new CalendarDate(date.year, date.month, 1));
 
-            // TODO: When other calendar than Gregorian or Julian are implemented, this may have to be changed
-            if (dayOfWeek !== undefined && (!isInteger(dayOfWeek) || dayOfWeek < 0 || dayOfWeek > 6)) throw new JDNConvertibleCalendarError('Invalid day of week: ' + dayOfWeek)
+        // first day of next month
+        let firstDayOfNextMonth;
 
+        // if the given date is in the last month of the year, switch to first day of the first month the next year.
+        if ((date.month + 1) > this.monthsInYear) {
+            firstDayOfNextMonth = this.calendarToJDN(new CalendarDate(date.year + 1, 1, 1));
+        } else {
+            // switch to the first day of the next month
+            firstDayOfNextMonth = this.calendarToJDN(new CalendarDate(date.year, date.month + 1, 1));
+        }
+
+        // calculate the difference between the first day of the month of the given day
+        // and the first day of the next month -> number of days of the month of the given date
+        return firstDayOfNextMonth - firstDayOfGivenMonth;
+    }
+
+    /**
+     * Converts the given JDN period to a calendar period and stores it.
+     *
+     * This method makes sure that JDNs and calendar dates are in sync. This method has no return value,
+     * it manipulates `this.calendarStart`, and `this.calendarEnd` instead.
+     *
+     * Do not manipulate members `this.exactDate`, `this.jdnStart`, `this.jdnEnd`, `this.calendarStart`, and `this.calendarEnd` directly,
+     * use this method instead.
+     *
+     * @param jdnPeriod the period defined by JDNs to be converted to a calendar period.
+     */
+    protected convertJDNPeriodToCalendarPeriod(jdnPeriod: JDNPeriod): void {
+
+        this.exactDate = jdnPeriod.exactDate;
+        this.jdnStart = jdnPeriod.periodStart;
+        this.jdnEnd = jdnPeriod.periodEnd;
+
+        // check if the date is exact (start of period equals end of period)
+        if (this.exactDate) {
+            // only one conversion needed
+            const date: CalendarDate = this.JDNToCalendar(jdnPeriod.periodStart);
+
+            // calculate the day of the week
+            const dayOfWeek = this.dayOfWeekFromJDN(jdnPeriod.periodStart);
+
+            const dateWithDayOfWeek = new CalendarDate(date.year, date.month, date.day, dayOfWeek);
+
+            this.calendarStart = dateWithDayOfWeek;
+            this.calendarEnd = dateWithDayOfWeek;
+        } else {
+            // calculate the days of the week
+            const dayOfWeekStart = this.dayOfWeekFromJDN(jdnPeriod.periodStart);
+            const dayOfWeekEnd = this.dayOfWeekFromJDN(jdnPeriod.periodEnd);
+
+            const dateStart = this.JDNToCalendar(jdnPeriod.periodStart);
+            const dateEnd = this.JDNToCalendar(jdnPeriod.periodEnd);
+
+            // calculate calendar dates for both start and end of period
+            this.calendarStart = new CalendarDate(dateStart.year, dateStart.month, dateStart.day, dayOfWeekStart);
+            this.calendarEnd = new CalendarDate(dateEnd.year, dateEnd.month, dateEnd.day, dayOfWeekEnd);
+
+        }
+    }
+
+    /**
+     * This constructor is inherited by all subclasses (no implementation in subclass required).
+     *
+     * The constructor supports two signatures:
+     * - period: JDNPeriod creates a date from the given `JDNPeriod` (two JDNs)
+     * - period: CalendarPeriod creates a date from the given `CalendarPeriod` (two calendar dates)
+     */
+    constructor(period: JDNPeriod);
+    constructor(period: CalendarPeriod);
+    constructor(period: any) {
+
+        // initialize members (required by TypeScript compiler)
+        const julianPeriodStart = new CalendarDate(-4712, 1, 1);
+
+        this.calendarStart = julianPeriodStart;
+
+        this.calendarEnd = julianPeriodStart;
+
+        this.exactDate = true;
+
+        this.jdnStart = 0;
+
+        this.jdnEnd = 0;
+
+        if (period instanceof JDNPeriod) {
+            // period is a JDNPeriod
+            this.convertJDNPeriodToCalendarPeriod(period);
+        } else {
+            // period is a CalendarPeriod
+
+            let jdnStart = this.calendarToJDN(period.periodStart);
+            let jdnEnd = this.calendarToJDN(period.periodEnd);
+
+            this.convertJDNPeriodToCalendarPeriod(new JDNPeriod(jdnStart, jdnEnd));
+        }
+    }
+
+    /**
+     * Returns the given period as two calendar dates.
+     *
+     * @returns period consisting of two calendar dates.
+     */
+    public toCalendarPeriod(): CalendarPeriod {
+        return new CalendarPeriod(this.calendarStart, this.calendarEnd);
+    }
+
+    /**
+     * Converts an instance of `JDNConvertibleCalendar` to a `JDNPeriod`.
+     *
+     * @returns period consisting of two JDNs.
+     */
+    public toJDNPeriod(): JDNPeriod {
+        return new JDNPeriod(this.jdnStart, this.jdnEnd);
+    }
+
+    /**
+     * Converts from one calendar into another.
+     *
+     * To be extended when new subclasses are added.
+     *
+     * @param {"Gregorian" | "Julian" | "Islamic"} toCalendarType calendar to convert to.
+     * @returns instance of target calendar (subclass of `JDNConvertibleCalendar`).
+     */
+    public convertCalendar(toCalendarType: 'Gregorian' | 'Julian' | 'Islamic'): JDNConvertibleCalendar {
+
+        if (JDNConvertibleCalendar.supportedCalendars.indexOf(toCalendarType) == -1) {
+            throw new JDNConvertibleCalendarError('Target calendar not supported: ' + toCalendarType);
+        }
+
+        if (this.calendarName == toCalendarType) return this; // no conversion needed
+
+        const jdnPeriod: JDNPeriod = this.toJDNPeriod();
+
+        // call constructor of subclass representing the target calendar
+        switch (toCalendarType) {
+            case JDNConvertibleCalendar.gregorian:
+                return new GregorianCalendarDate(jdnPeriod);
+
+            case JDNConvertibleCalendar.julian:
+                return new JulianCalendarDate(jdnPeriod);
+
+            case JDNConvertibleCalendar.islamic:
+                return new IslamicCalendarDate(jdnPeriod);
         }
 
     }
 
     /**
-     * Represents a period as two calendar dates.
+     * Transposes the current period by the given number of days.
+     *
+     * @param days the number of days that the current period will be shifted.
      */
-    export class CalendarPeriod {
+    public transposePeriodByDay(days: number): void {
 
-        /**
-         *
-         * @param periodStart start of the period.
-         * @param periodEnd End of the period.
-         */
-        constructor(public readonly periodStart: CalendarDate, public readonly periodEnd: CalendarDate) {
+        if (days === 0) return;
 
-            // TODO: can we check that periodStart equals or is before periodEnd?
+        if (!Utils.isInteger(days)) throw new JDNConvertibleCalendarError(`parameter "days" is expected to be an integer`);
 
+        const currentPeriod = this.toJDNPeriod();
+
+        const newPeriod = new JDNPeriod(currentPeriod.periodStart + days, currentPeriod.periodEnd + days);
+
+        this.convertJDNPeriodToCalendarPeriod(newPeriod);
+    }
+
+    /**
+     * Transposes the current period by the given number of years.
+     *
+     * This method is not accurate in the arithmetical sense: it tries to fit the given day in the month of the new year.
+     * If this is not possible, it takes the last day of the new month (e.g., February 29 will become the last possible day of February).
+     *
+     * @param years the number of years that the current period will be shifted.
+     */
+    public transposePeriodByYear(years: number): void {
+
+        if (years === 0) return;
+
+        if (!Utils.isInteger(years)) throw new JDNConvertibleCalendarError(`parameter "years" is expected to be an integer`);
+
+        const currentCalendarPeriod = this.toCalendarPeriod();
+
+        let newJDNPeriod: JDNPeriod;
+
+        // indicates if the shifting is towards the future or the past
+        const intoTheFuture: Boolean = (years > 0);
+
+        if (this.exactDate) {
+
+            let yearZeroCorrection = 0;
+            // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
+            if (!this.yearZeroExists && intoTheFuture && currentCalendarPeriod.periodStart.year < 1 && (currentCalendarPeriod.periodStart.year + years > -1)) {
+                yearZeroCorrection = 1;
+                // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
+            } else if (!this.yearZeroExists && !intoTheFuture && currentCalendarPeriod.periodStart.year > -1 && (currentCalendarPeriod.periodStart.year + years < 1)) {
+                yearZeroCorrection = -1;
+            }
+
+            // determine max. number of days in the new month
+            const maxDaysInNewMonth: number = this.daysInMonth(new CalendarDate(currentCalendarPeriod.periodStart.year + years + yearZeroCorrection, currentCalendarPeriod.periodStart.month, 1));
+
+            const newCalendarDate = new CalendarDate(
+                currentCalendarPeriod.periodStart.year + years + yearZeroCorrection,
+                currentCalendarPeriod.periodStart.month,
+                (currentCalendarPeriod.periodStart.day > maxDaysInNewMonth) ? maxDaysInNewMonth : currentCalendarPeriod.periodStart.day
+            );
+
+            let newJDN = this.calendarToJDN(newCalendarDate);
+
+            newJDNPeriod = new JDNPeriod(newJDN, newJDN);
+
+        } else {
+
+            let yearZeroCorrectionStart = 0;
+            // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
+            if (!this.yearZeroExists && intoTheFuture && currentCalendarPeriod.periodStart.year < 1 && (currentCalendarPeriod.periodStart.year + years > -1)) {
+                yearZeroCorrectionStart = 1;
+                // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
+            } else if (!this.yearZeroExists && !intoTheFuture && currentCalendarPeriod.periodStart.year > -1 && (currentCalendarPeriod.periodStart.year + years < 1)) {
+                yearZeroCorrectionStart = -1;
+            }
+
+            // determine max. number of days in the new month
+            const maxDaysInNewMonthStart: number = this.daysInMonth(new CalendarDate(currentCalendarPeriod.periodStart.year + years + yearZeroCorrectionStart, currentCalendarPeriod.periodStart.month, 1));
+
+            const newCalendarDateStart = new CalendarDate(
+                currentCalendarPeriod.periodStart.year + years + yearZeroCorrectionStart,
+                currentCalendarPeriod.periodStart.month,
+                (currentCalendarPeriod.periodStart.day > maxDaysInNewMonthStart) ? maxDaysInNewMonthStart : currentCalendarPeriod.periodStart.day
+            );
+
+            let newJDNStart = this.calendarToJDN(newCalendarDateStart);
+
+            let yearZeroCorrectionEnd = 0;
+            // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
+            if (!this.yearZeroExists && intoTheFuture && currentCalendarPeriod.periodEnd.year < 1 && (currentCalendarPeriod.periodEnd.year + years > -1)) {
+                yearZeroCorrectionEnd = 1;
+                // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
+            } else if (!this.yearZeroExists && !intoTheFuture && currentCalendarPeriod.periodEnd.year > -1 && (currentCalendarPeriod.periodEnd.year + years < 1)) {
+                yearZeroCorrectionEnd = -1;
+            }
+
+            // determine max. number of days in the new month
+            const maxDaysInNewMonthEnd: number = this.daysInMonth(new CalendarDate(currentCalendarPeriod.periodEnd.year + years + yearZeroCorrectionEnd, currentCalendarPeriod.periodEnd.month, 1));
+
+            const newCalendarDateEnd = new CalendarDate(
+                currentCalendarPeriod.periodEnd.year + years + yearZeroCorrectionEnd,
+                currentCalendarPeriod.periodEnd.month,
+                (currentCalendarPeriod.periodEnd.day > maxDaysInNewMonthEnd) ? maxDaysInNewMonthEnd : currentCalendarPeriod.periodEnd.day
+            );
+
+            let newJDNEnd = this.calendarToJDN(newCalendarDateEnd);
+
+            newJDNPeriod = new JDNPeriod(newJDNStart, newJDNEnd);
         }
+
+        this.convertJDNPeriodToCalendarPeriod(newJDNPeriod);
 
     }
 
     /**
-     * Represents a period as two JDNs.
+     * Converts the given calendar date to a new one, shifting the months by the given number.
+     *
+     * @param calendarDate the given calendar date.
+     * @param months the number of months to shift.
+     * @returns calendar transposed by the given number of months.
      */
-    export class JDNPeriod {
+    protected handleMonthTransposition(calendarDate: CalendarDate, months: number): CalendarDate {
 
-        /**
-         * Indicates if the date is exact (day precision).
-         */
-        public readonly exactDate: Boolean;
+        if (months === 0) return calendarDate;
 
-        /**
-         *
-         * @param periodStart start of the period.
-         * @param periodEnd End of the period.
-         */
-        constructor(public readonly periodStart: JDN, public readonly periodEnd: JDN) {
+        if (!Utils.isInteger(months)) throw new JDNConvertibleCalendarError(`parameter "months" is expected to be an integer`);
 
-            // check that periodStart equals or is before periodEnd
-            if (periodStart > periodEnd) throw new JDNConvertibleCalendarError(`start of a JDNPeriod must not be greater than its end`);
+        // indicates if the shifting is towards the future or the past
+        const intoTheFuture: Boolean = (months > 0);
 
-            // check that given arguments are integers (JDNs have no fractions)
-            if (!(isInteger(periodStart) && isInteger(periodEnd))) {
-                throw new JDNConvertibleCalendarError('JDNs are expected to be integers');
-            }
+        // get number of full years to shift
+        const yearsToShift = Math.floor(Math.abs(months) / this.monthsInYear);
 
-            this.exactDate = (periodStart === periodEnd);
+        // get remaining months to shift: max. this.monthsInYear - 1
+        const monthsToShift = Math.abs(months) % this.monthsInYear;
 
-        }
-    }
+        let newCalendarDate: CalendarDate;
 
-    /**
-     * Abstract class representing any calendar
-     * that can be converted from and to a Julian Day.
-     */
-    export abstract class JDNConvertibleCalendar {
+        if (intoTheFuture) {
+            // switch to the next year if the number of months does not fit
+            if (calendarDate.month + monthsToShift > this.monthsInYear) {
 
-        /**
-         * Constant for the Gregorian calendar.
-         */
-        protected static readonly gregorian = 'Gregorian';
+                // months to be added to new year
+                const monthsOverflow = calendarDate.month + monthsToShift - this.monthsInYear;
 
-        /**
-         * Constant for the Julian calendar.
-         */
-        protected static readonly julian = 'Julian';
-
-        /**
-         * Constant for the Islamic calendar.
-         */
-        protected static readonly islamic = 'Islamic';
-
-        /**
-         * Supported calendars (to be extended when new subclasses are implemented).
-         */
-        public static readonly supportedCalendars = [JDNConvertibleCalendar.gregorian, JDNConvertibleCalendar.julian, JDNConvertibleCalendar.islamic];
-
-        /**
-         * Calendar name of a subclass of `JDNConvertibleCalendar`.
-         */
-        public abstract readonly calendarName: string;
-
-        /**
-         * Indicates how many months a year has in a specific calendar.
-         */
-        public abstract readonly monthsInYear: number;
-
-        /**
-         * Indicates if the year 0 exists in a specific calendar.
-         */
-        public abstract readonly yearZeroExists: Boolean;
-
-        //
-        // Both calendar dates and JDNs are stored in parallel to avoid unnecessary conversions (JDN to calendar date and possibly back to JDN).
-        // Manipulations are exclusively performed by `this.convertJDNPeriodToCalendarPeriod` that keeps them in sync.
-        //
-
-        /**
-         * Start of a given date in a specific calendar.
-         */
-        protected calendarStart: CalendarDate;
-
-        /**
-         * End of a given date in a specific calendar.
-         */
-        protected calendarEnd: CalendarDate;
-
-        /**
-         * Indicates if the date is exact (start and end of the given period are equal).
-         */
-        protected exactDate: Boolean;
-
-        /**
-         * Start of given date as JDN.
-         */
-        protected jdnStart: JDN;
-
-        /**
-         * End of given date as JDN.
-         */
-        protected jdnEnd: JDN;
-
-        /**
-         * Converts a given JDN to a calendar date.
-         * This method has to be implemented for each subclass
-         * (specific calendar).
-         *
-         * Attention: depending on the conventions used, there may be a year 0 or not.
-         * This depends on the implementation of this conversion function.
-         *
-         * @param jdn JDN to be converted to a calendar date.
-         * @returns calendar date created from given JDN.
-         */
-        protected abstract JDNToCalendar(jdn: JDN): CalendarDate;
-
-        /**
-         * Converts a given calendar date to JDN.
-         * This method has to be implemented for each subclass
-         * (specific calendar).
-         *
-         * Attention: depending on the conventions used, there may be a year 0 or not.
-         * This depends on the implementation of this conversion function.
-         *
-         * @param date calendar date to be converted to a JDN.
-         * @returns JDN created from given calendar date.
-         */
-        protected abstract calendarToJDN(date: CalendarDate): JDN;
-
-        /**
-         * Calculates the day of week of a given JDN.
-         *
-         * @param jdn JDN for which the day of the week is to be calculated.
-         * @returns day of week of the given JDN (as a 0-based index).
-         */
-        protected abstract dayOfWeekFromJDN(jdn: JDN): number;
-
-        /**
-         * Calculates number of days for the month of the given date.
-         *
-         * The given date is expected to be of the same calendar as the instance the method is called on.
-         *
-         * @param date given date.
-         * @returns number of days in month of given date.
-         */
-        public daysInMonth(date: CalendarDate): number {
-
-            // get JDN for first day of the month of the given calendar date
-            const firstDayOfGivenMonth = this.calendarToJDN(new CalendarDate(date.year, date.month, 1));
-
-            // first day of next month
-            let firstDayOfNextMonth;
-
-            // if the given date is in the last month of the year, switch to first day of the first month the next year.
-            if ((date.month + 1) > this.monthsInYear) {
-                firstDayOfNextMonth = this.calendarToJDN(new CalendarDate(date.year + 1, 1, 1));
-            }
-            else {
-                // switch to the first day of the next month
-                firstDayOfNextMonth = this.calendarToJDN(new CalendarDate(date.year, date.month + 1, 1));
-            }
-
-            // calculate the difference between the first day of the month of the given day
-            // and the first day of the next month -> number of days of the month of the given date
-            return firstDayOfNextMonth - firstDayOfGivenMonth;
-        }
-
-        /**
-         * Converts the given JDN period to a calendar period and stores it.
-         *
-         * This method makes sure that JDNs and calendar dates are in sync. This method has no return value,
-         * it manipulates `this.calendarStart`, and `this.calendarEnd` instead.
-         *
-         * Do not manipulate members `this.exactDate`, `this.jdnStart`, `this.jdnEnd`, `this.calendarStart`, and `this.calendarEnd` directly,
-         * use this method instead.
-         *
-         * @param jdnPeriod the period defined by JDNs to be converted to a calendar period.
-         */
-        protected convertJDNPeriodToCalendarPeriod(jdnPeriod: JDNPeriod): void {
-
-            this.exactDate = jdnPeriod.exactDate;
-            this.jdnStart = jdnPeriod.periodStart;
-            this.jdnEnd = jdnPeriod.periodEnd;
-
-            // check if the date is exact (start of period equals end of period)
-            if (this.exactDate) {
-                // only one conversion needed
-                const date: CalendarDate = this.JDNToCalendar(jdnPeriod.periodStart);
-
-                // calculate the day of the week
-                const dayOfWeek = this.dayOfWeekFromJDN(jdnPeriod.periodStart);
-
-                const dateWithDayOfWeek = new CalendarDate(date.year, date.month, date.day, dayOfWeek);
-
-                this.calendarStart = dateWithDayOfWeek;
-                this.calendarEnd = dateWithDayOfWeek;
-            } else {
-                // calculate the days of the week
-                const dayOfWeekStart = this.dayOfWeekFromJDN(jdnPeriod.periodStart);
-                const dayOfWeekEnd = this.dayOfWeekFromJDN(jdnPeriod.periodEnd);
-
-                const dateStart = this.JDNToCalendar(jdnPeriod.periodStart);
-                const dateEnd = this.JDNToCalendar(jdnPeriod.periodEnd);
-
-                // calculate calendar dates for both start and end of period
-                this.calendarStart = new CalendarDate(dateStart.year, dateStart.month, dateStart.day, dayOfWeekStart);
-                this.calendarEnd = new CalendarDate(dateEnd.year, dateEnd.month, dateEnd.day, dayOfWeekEnd);
-
-            }
-        }
-
-        /**
-         * This constructor is inherited by all subclasses (no implementation in subclass required).
-         *
-         * The constructor supports two signatures:
-         * - period: JDNPeriod creates a date from the given `JDNPeriod` (two JDNs)
-         * - period: CalendarPeriod creates a date from the given `CalendarPeriod` (two calendar dates)
-         */
-        constructor(period: JDNPeriod);
-        constructor(period: CalendarPeriod);
-        constructor(period: any) {
-
-            // initialize members (required by TypeScript compiler)
-            const julianPeriodStart = new CalendarDate(-4712, 1, 1);
-
-            this.calendarStart = julianPeriodStart;
-
-            this.calendarEnd = julianPeriodStart;
-
-            this.exactDate = true;
-
-            this.jdnStart = 0;
-
-            this.jdnEnd = 0;
-
-            if (period instanceof JDNPeriod) {
-                // period is a JDNPeriod
-                this.convertJDNPeriodToCalendarPeriod(period);
-            } else {
-                // period is a CalendarPeriod
-
-                let jdnStart = this.calendarToJDN(period.periodStart);
-                let jdnEnd = this.calendarToJDN(period.periodEnd);
-
-                this.convertJDNPeriodToCalendarPeriod(new JDNPeriod(jdnStart, jdnEnd));
-            }
-        }
-
-        /**
-         * Returns the given period as two calendar dates.
-         *
-         * @returns period consisting of two calendar dates.
-         */
-        public toCalendarPeriod(): CalendarPeriod {
-            return new CalendarPeriod(this.calendarStart, this.calendarEnd);
-        }
-
-        /**
-         * Converts an instance of `JDNConvertibleCalendar` to a `JDNPeriod`.
-         *
-         * @returns period consisting of two JDNs.
-         */
-        public toJDNPeriod(): JDNPeriod {
-            return new JDNPeriod(this.jdnStart, this.jdnEnd);
-        }
-
-        /**
-         * Converts from one calendar into another.
-         *
-         * To be extended when new subclasses are added.
-         *
-         * @param {"Gregorian" | "Julian" | "Islamic"} toCalendarType calendar to convert to.
-         * @returns instance of target calendar (subclass of `JDNConvertibleCalendar`).
-         */
-        public convertCalendar(toCalendarType: 'Gregorian' | 'Julian' | 'Islamic'): JDNConvertibleCalendar {
-
-            if (JDNConvertibleCalendar.supportedCalendars.indexOf(toCalendarType) == -1) {
-                throw new JDNConvertibleCalendarError('Target calendar not supported: ' + toCalendarType);
-            }
-
-            if (this.calendarName == toCalendarType) return this; // no conversion needed
-
-            const jdnPeriod: JDNPeriod = this.toJDNPeriod();
-
-            // call constructor of subclass representing the target calendar
-            switch (toCalendarType) {
-                case JDNConvertibleCalendar.gregorian:
-                    return new GregorianCalendarDate(jdnPeriod);
-
-                case JDNConvertibleCalendar.julian:
-                    return new JulianCalendarDate(jdnPeriod);
-
-                case JDNConvertibleCalendar.islamic:
-                    return new IslamicCalendarDate(jdnPeriod);
-            }
-
-        }
-
-        /**
-         * Transposes the current period by the given number of days.
-         *
-         * @param days the number of days that the current period will be shifted.
-         */
-        public transposePeriodByDay(days: number): void {
-
-            if (days === 0) return;
-
-            if (!isInteger(days)) throw new JDNConvertibleCalendarError(`parameter "days" is expected to be an integer`);
-
-            const currentPeriod = this.toJDNPeriod();
-
-            const newPeriod = new JDNPeriod(currentPeriod.periodStart + days, currentPeriod.periodEnd + days);
-
-            this.convertJDNPeriodToCalendarPeriod(newPeriod);
-        }
-
-        /**
-         * Transposes the current period by the given number of years.
-         *
-         * This method is not accurate in the arithmetical sense: it tries to fit the given day in the month of the new year.
-         * If this is not possible, it takes the last day of the new month (e.g., February 29 will become the last possible day of February).
-         *
-         * @param years the number of years that the current period will be shifted.
-         */
-        public transposePeriodByYear(years: number): void {
-
-            if (years === 0) return;
-
-            if (!isInteger(years)) throw new JDNConvertibleCalendarError(`parameter "years" is expected to be an integer`);
-
-            const currentCalendarPeriod = this.toCalendarPeriod();
-
-            let newJDNPeriod: JDNPeriod;
-
-            // indicates if the shifting is towards the future or the past
-            const intoTheFuture: Boolean = (years > 0);
-
-            if (this.exactDate) {
-
-                let yearZeroCorrection = 0;
                 // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
-                if (!this.yearZeroExists && intoTheFuture && currentCalendarPeriod.periodStart.year < 1 && (currentCalendarPeriod.periodStart.year + years > -1)) {
+                let yearZeroCorrection = 0;
+                if (!this.yearZeroExists && calendarDate.year < 1 && (calendarDate.year + yearsToShift + 1 > -1)) {
                     yearZeroCorrection = 1;
-                    // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
-                } else if (!this.yearZeroExists && !intoTheFuture && currentCalendarPeriod.periodStart.year > -1 && (currentCalendarPeriod.periodStart.year + years < 1)) {
+                }
+
+                // determine max. number of days in the new month
+                const maxDaysInNewMonth: number = this.daysInMonth(new CalendarDate(calendarDate.year + yearsToShift + 1 + yearZeroCorrection, monthsOverflow, 1));
+
+                newCalendarDate = new CalendarDate(
+                    calendarDate.year + yearsToShift + 1 + yearZeroCorrection, // add an extra year
+                    monthsOverflow,
+                    (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
+                );
+            } else {
+
+                // determine max. number of days in the new month
+                const maxDaysInNewMonth = this.daysInMonth(new CalendarDate(calendarDate.year + yearsToShift, calendarDate.month + monthsToShift, 1));
+
+                newCalendarDate = new CalendarDate(
+                    calendarDate.year + yearsToShift,
+                    calendarDate.month + monthsToShift,
+                    (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
+                );
+
+            }
+        } else {
+            // switch to the previous year if the number of months does not fit
+            if (calendarDate.month - monthsToShift < 1) {
+
+                // months to be subtracted from the previous year
+                const newMonth = this.monthsInYear - (monthsToShift - calendarDate.month);
+
+                // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
+                let yearZeroCorrection = 0;
+                if (!this.yearZeroExists && calendarDate.year > -1 && (calendarDate.year - yearsToShift - 1 < 1)) {
                     yearZeroCorrection = -1;
                 }
 
                 // determine max. number of days in the new month
-                const maxDaysInNewMonth: number = this.daysInMonth(new CalendarDate(currentCalendarPeriod.periodStart.year + years + yearZeroCorrection, currentCalendarPeriod.periodStart.month, 1));
+                const maxDaysInNewMonth = this.daysInMonth(new CalendarDate(calendarDate.year - yearsToShift - 1 + yearZeroCorrection, newMonth, 1));
 
-                const newCalendarDate = new CalendarDate(
-                        currentCalendarPeriod.periodStart.year + years + yearZeroCorrection,
-                        currentCalendarPeriod.periodStart.month,
-                        (currentCalendarPeriod.periodStart.day > maxDaysInNewMonth) ? maxDaysInNewMonth : currentCalendarPeriod.periodStart.day
+                newCalendarDate = new CalendarDate(
+                    calendarDate.year - yearsToShift - 1 + yearZeroCorrection, // subtract an extra year
+                    newMonth,
+                    (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
                 );
 
-                let newJDN = this.calendarToJDN(newCalendarDate);
-
-                newJDNPeriod = new JDNPeriod(newJDN, newJDN);
-
             } else {
-
-                let yearZeroCorrectionStart = 0;
-                // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
-                if (!this.yearZeroExists && intoTheFuture && currentCalendarPeriod.periodStart.year < 1 && (currentCalendarPeriod.periodStart.year + years > -1)) {
-                    yearZeroCorrectionStart = 1;
-                    // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
-                } else if (!this.yearZeroExists && !intoTheFuture && currentCalendarPeriod.periodStart.year > -1 && (currentCalendarPeriod.periodStart.year + years < 1)) {
-                    yearZeroCorrectionStart = -1;
-                }
 
                 // determine max. number of days in the new month
-                const maxDaysInNewMonthStart: number = this.daysInMonth(new CalendarDate(currentCalendarPeriod.periodStart.year + years + yearZeroCorrectionStart, currentCalendarPeriod.periodStart.month, 1));
+                const maxDaysInNewMonth = this.daysInMonth(new CalendarDate(calendarDate.year - yearsToShift, calendarDate.month - monthsToShift, 1));
 
-                const newCalendarDateStart = new CalendarDate(
-                        currentCalendarPeriod.periodStart.year + years + yearZeroCorrectionStart,
-                        currentCalendarPeriod.periodStart.month,
-                        (currentCalendarPeriod.periodStart.day > maxDaysInNewMonthStart) ? maxDaysInNewMonthStart : currentCalendarPeriod.periodStart.day
+                newCalendarDate = new CalendarDate(
+                    calendarDate.year - yearsToShift,
+                    calendarDate.month - monthsToShift,
+                    (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
                 );
 
-                let newJDNStart = this.calendarToJDN(newCalendarDateStart);
-
-                let yearZeroCorrectionEnd = 0;
-                // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
-                if (!this.yearZeroExists && intoTheFuture && currentCalendarPeriod.periodEnd.year < 1 && (currentCalendarPeriod.periodEnd.year + years > -1)) {
-                    yearZeroCorrectionEnd = 1;
-                    // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
-                } else if (!this.yearZeroExists && !intoTheFuture && currentCalendarPeriod.periodEnd.year > -1 && (currentCalendarPeriod.periodEnd.year + years < 1)) {
-                    yearZeroCorrectionEnd = -1;
-                }
-
-                // determine max. number of days in the new month
-                const maxDaysInNewMonthEnd: number = this.daysInMonth(new CalendarDate(currentCalendarPeriod.periodEnd.year + years + yearZeroCorrectionEnd, currentCalendarPeriod.periodEnd.month, 1));
-
-                const newCalendarDateEnd = new CalendarDate(
-                        currentCalendarPeriod.periodEnd.year + years + yearZeroCorrectionEnd,
-                        currentCalendarPeriod.periodEnd.month,
-                        (currentCalendarPeriod.periodEnd.day > maxDaysInNewMonthEnd) ? maxDaysInNewMonthEnd : currentCalendarPeriod.periodEnd.day
-                );
-
-                let newJDNEnd = this.calendarToJDN(newCalendarDateEnd);
-
-                newJDNPeriod = new JDNPeriod(newJDNStart, newJDNEnd);
             }
-
-            this.convertJDNPeriodToCalendarPeriod(newJDNPeriod);
-
         }
 
-        /**
-         * Converts the given calendar date to a new one, shifting the months by the given number.
-         *
-         * @param calendarDate the given calendar date.
-         * @param months the number of months to shift.
-         * @returns calendar transposed by the given number of months.
-         */
-        protected handleMonthTransposition(calendarDate: CalendarDate, months: number): CalendarDate {
-
-            if (months === 0) return calendarDate;
-
-            if (!isInteger(months)) throw new JDNConvertibleCalendarError(`parameter "months" is expected to be an integer`);
-
-            // indicates if the shifting is towards the future or the past
-            const intoTheFuture: Boolean = (months > 0);
-
-            // get number of full years to shift
-            const yearsToShift = Math.floor(Math.abs(months) / this.monthsInYear);
-
-            // get remaining months to shift: max. this.monthsInYear - 1
-            const monthsToShift = Math.abs(months) % this.monthsInYear;
-
-            let newCalendarDate: CalendarDate;
-
-            if (intoTheFuture) {
-                // switch to the next year if the number of months does not fit
-                if (calendarDate.month + monthsToShift > this.monthsInYear) {
-
-                    // months to be added to new year
-                    const monthsOverflow = calendarDate.month + monthsToShift - this.monthsInYear;
-
-                    // when switching from a negative to a negative year and the year zero does not exist in the calendar used, correct it.
-                    let yearZeroCorrection = 0;
-                    if (!this.yearZeroExists && calendarDate.year < 1 && (calendarDate.year + yearsToShift + 1 > -1)) {
-                        yearZeroCorrection = 1;
-                    }
-
-                    // determine max. number of days in the new month
-                    const maxDaysInNewMonth: number = this.daysInMonth(new CalendarDate(calendarDate.year + yearsToShift + 1 + yearZeroCorrection, monthsOverflow, 1));
-
-                    newCalendarDate = new CalendarDate(
-                            calendarDate.year + yearsToShift + 1 + yearZeroCorrection, // add an extra year
-                            monthsOverflow,
-                            (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
-                    );
-                } else {
-
-                    // determine max. number of days in the new month
-                    const maxDaysInNewMonth = this.daysInMonth(new CalendarDate(calendarDate.year + yearsToShift, calendarDate.month + monthsToShift, 1));
-
-                    newCalendarDate = new CalendarDate(
-                            calendarDate.year + yearsToShift,
-                            calendarDate.month + monthsToShift,
-                            (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
-                    );
-
-                }
-            } else {
-                // switch to the previous year if the number of months does not fit
-                if (calendarDate.month - monthsToShift < 1) {
-
-                    // months to be subtracted from the previous year
-                    const newMonth = this.monthsInYear - (monthsToShift - calendarDate.month);
-
-                    // when switching from a positive to a negative year and the year zero does not exist in the calendar used, correct it.
-                    let yearZeroCorrection = 0;
-                    if (!this.yearZeroExists && calendarDate.year > -1 && (calendarDate.year - yearsToShift - 1 < 1)) {
-                        yearZeroCorrection = -1;
-                    }
-
-                    // determine max. number of days in the new month
-                    const maxDaysInNewMonth = this.daysInMonth(new CalendarDate(calendarDate.year - yearsToShift - 1 + yearZeroCorrection, newMonth, 1));
-
-                    newCalendarDate = new CalendarDate(
-                            calendarDate.year - yearsToShift - 1 + yearZeroCorrection, // subtract an extra year
-                            newMonth,
-                            (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
-                    );
-
-                } else {
-
-                    // determine max. number of days in the new month
-                    const maxDaysInNewMonth = this.daysInMonth(new CalendarDate(calendarDate.year - yearsToShift, calendarDate.month - monthsToShift, 1));
-
-                    newCalendarDate = new CalendarDate(
-                            calendarDate.year - yearsToShift,
-                            calendarDate.month - monthsToShift,
-                            (calendarDate.day > maxDaysInNewMonth) ? maxDaysInNewMonth : calendarDate.day
-                    );
-
-                }
-            }
-
-            return newCalendarDate;
-        }
-
-        /**
-         * Transposes the current period by the given number of months.
-         *
-         * This method is not accurate in the arithmetical sense: it tries to fit the given day in the new month.
-         * If this is not possible, it takes the last day of the new month (e.g., January 31 will become the last possible day of February).
-         *
-         * @param months the number of months that the current period will be shifted.
-         */
-        public transposePeriodByMonth(months: number): void {
-
-            if (months === 0) return;
-
-            if (!isInteger(months)) throw new JDNConvertibleCalendarError(`parameter "months" is expected to be an integer`);
-
-            const currentCalendarPeriod = this.toCalendarPeriod();
-
-            let newJDNPeriod: JDNPeriod;
-
-            if (this.exactDate) {
-
-                const newCalDate = this.handleMonthTransposition(currentCalendarPeriod.periodStart, months);
-
-                const newJDN = this.calendarToJDN(newCalDate);
-
-                newJDNPeriod = new JDNPeriod(newJDN, newJDN);
-
-            } else {
-
-                const newCalDateStart = this.handleMonthTransposition(currentCalendarPeriod.periodStart, months);
-
-                const newJDNStart = this.calendarToJDN(newCalDateStart);
-
-                const newCalDateEnd = this.handleMonthTransposition(currentCalendarPeriod.periodEnd, months);
-
-                const newJDNEnd = this.calendarToJDN(newCalDateEnd);
-
-                newJDNPeriod = new JDNPeriod(newJDNStart, newJDNEnd);
-
-            }
-
-            this.convertJDNPeriodToCalendarPeriod(newJDNPeriod);
-
-        }
-
-    }
-
-
-    /**
-     * Represents a Gregorian calendar date.
-     */
-    export class GregorianCalendarDate extends JDNConvertibleCalendar {
-
-        public readonly calendarName = JDNConvertibleCalendar.gregorian;
-
-        public readonly monthsInYear = 12;
-
-        // We use calendar conversion methods that use the convention
-        // that the year zero exists in the Gregorian Calendar.
-        public readonly yearZeroExists = true;
-
-        protected JDNToCalendar(jdn: JDN): CalendarDate {
-            return JDNConvertibleConversionModule.JDNToGregorian(jdn);
-        };
-
-        protected calendarToJDN(date: CalendarDate): JDN {
-            return JDNConvertibleConversionModule.gregorianToJDN(date);
-        }
-
-        protected dayOfWeekFromJDN(jdn: number): number {
-            return JDNConvertibleConversionModule.dayOfWeekFromJDC(jdn);
-        };
-
+        return newCalendarDate;
     }
 
     /**
-     * Represents a Julian calendar date.
+     * Transposes the current period by the given number of months.
+     *
+     * This method is not accurate in the arithmetical sense: it tries to fit the given day in the new month.
+     * If this is not possible, it takes the last day of the new month (e.g., January 31 will become the last possible day of February).
+     *
+     * @param months the number of months that the current period will be shifted.
      */
-    export class JulianCalendarDate extends JDNConvertibleCalendar {
+    public transposePeriodByMonth(months: number): void {
 
-        public readonly calendarName = JDNConvertibleCalendar.julian;
+        if (months === 0) return;
 
-        public readonly monthsInYear = 12;
+        if (!Utils.isInteger(months)) throw new JDNConvertibleCalendarError(`parameter "months" is expected to be an integer`);
 
-        // We use calendar conversion methods that use the convention
-        // that the year zero does exist in the Julian Calendar.
-        public readonly yearZeroExists = true;
+        const currentCalendarPeriod = this.toCalendarPeriod();
 
-        protected JDNToCalendar(jdn: JDN): CalendarDate {
-            return JDNConvertibleConversionModule.JDNToJulian(jdn);
+        let newJDNPeriod: JDNPeriod;
+
+        if (this.exactDate) {
+
+            const newCalDate = this.handleMonthTransposition(currentCalendarPeriod.periodStart, months);
+
+            const newJDN = this.calendarToJDN(newCalDate);
+
+            newJDNPeriod = new JDNPeriod(newJDN, newJDN);
+
+        } else {
+
+            const newCalDateStart = this.handleMonthTransposition(currentCalendarPeriod.periodStart, months);
+
+            const newJDNStart = this.calendarToJDN(newCalDateStart);
+
+            const newCalDateEnd = this.handleMonthTransposition(currentCalendarPeriod.periodEnd, months);
+
+            const newJDNEnd = this.calendarToJDN(newCalDateEnd);
+
+            newJDNPeriod = new JDNPeriod(newJDNStart, newJDNEnd);
+
         }
 
-        protected calendarToJDN(date: CalendarDate): JDN {
-            return JDNConvertibleConversionModule.julianToJDN(date);
-        }
+        this.convertJDNPeriodToCalendarPeriod(newJDNPeriod);
 
-        protected dayOfWeekFromJDN(jdn: JDN): number {
-            return JDNConvertibleConversionModule.dayOfWeekFromJDC(jdn);
-        };
-    }
-
-    /**
-     * Represents an Islamic calendar date.
-     */
-    export class IslamicCalendarDate extends JDNConvertibleCalendar {
-
-        public readonly calendarName = JDNConvertibleCalendar.islamic;
-
-        public readonly monthsInYear = 12;
-
-        // We use calendar conversion methods that use the convention
-        // that the year zero does exist in the Julian Calendar.
-        public readonly yearZeroExists = true;
-
-        protected JDNToCalendar(jdn: JDN): CalendarDate {
-            return JDNConvertibleConversionModule.JDNToIslamic(jdn);
-        }
-
-        protected calendarToJDN(date: CalendarDate): JDN {
-            return JDNConvertibleConversionModule.islamicToJDN(date);
-        }
-
-        protected dayOfWeekFromJDN(jdn: JDN): number {
-            return JDNConvertibleConversionModule.dayOfWeekFromJDC(jdn);
-        };
     }
 
 }
+
+
+/**
+ * Represents a Gregorian calendar date.
+ */
+export class GregorianCalendarDate extends JDNConvertibleCalendar {
+
+    public readonly calendarName = JDNConvertibleCalendar.gregorian;
+
+    public readonly monthsInYear = 12;
+
+    // We use calendar conversion methods that use the convention
+    // that the year zero exists in the Gregorian Calendar.
+    public readonly yearZeroExists = true;
+
+    protected JDNToCalendar(jdn: TypeDefinitionsModule.JDN): CalendarDate {
+        return JDNConvertibleConversionModule.JDNToGregorian(jdn);
+    };
+
+    protected calendarToJDN(date: CalendarDate): TypeDefinitionsModule.JDN {
+        return JDNConvertibleConversionModule.gregorianToJDN(date);
+    }
+
+    protected dayOfWeekFromJDN(jdn: number): number {
+        return JDNConvertibleConversionModule.dayOfWeekFromJDC(jdn);
+    };
+
+}
+
+/**
+ * Represents a Julian calendar date.
+ */
+export class JulianCalendarDate extends JDNConvertibleCalendar {
+
+    public readonly calendarName = JDNConvertibleCalendar.julian;
+
+    public readonly monthsInYear = 12;
+
+    // We use calendar conversion methods that use the convention
+    // that the year zero does exist in the Julian Calendar.
+    public readonly yearZeroExists = true;
+
+    protected JDNToCalendar(jdn: TypeDefinitionsModule.JDN): CalendarDate {
+        return JDNConvertibleConversionModule.JDNToJulian(jdn);
+    }
+
+    protected calendarToJDN(date: CalendarDate): TypeDefinitionsModule.JDN {
+        return JDNConvertibleConversionModule.julianToJDN(date);
+    }
+
+    protected dayOfWeekFromJDN(jdn: TypeDefinitionsModule.JDN): number {
+        return JDNConvertibleConversionModule.dayOfWeekFromJDC(jdn);
+    };
+}
+
+/**
+ * Represents an Islamic calendar date.
+ */
+export class IslamicCalendarDate extends JDNConvertibleCalendar {
+
+    public readonly calendarName = JDNConvertibleCalendar.islamic;
+
+    public readonly monthsInYear = 12;
+
+    // We use calendar conversion methods that use the convention
+    // that the year zero does exist in the Julian Calendar.
+    public readonly yearZeroExists = true;
+
+    protected JDNToCalendar(jdn: TypeDefinitionsModule.JDN): CalendarDate {
+        return JDNConvertibleConversionModule.JDNToIslamic(jdn);
+    }
+
+    protected calendarToJDN(date: CalendarDate): TypeDefinitionsModule.JDN {
+        return JDNConvertibleConversionModule.islamicToJDN(date);
+    }
+
+    protected dayOfWeekFromJDN(jdn: TypeDefinitionsModule.JDN): number {
+        return JDNConvertibleConversionModule.dayOfWeekFromJDC(jdn);
+    };
+}
+
+

--- a/src/JDNConvertibleCalendar.ts
+++ b/src/JDNConvertibleCalendar.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
  * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
  *
  * This file is part of JDNConvertibleCalendar.

--- a/src/JDNConvertibleCalendarError.ts
+++ b/src/JDNConvertibleCalendarError.ts
@@ -1,0 +1,13 @@
+/**
+ * Represents an error that occurred when using `JDNConvertibleCalendarModule`.
+ */
+export class JDNConvertibleCalendarError extends Error {
+
+    /**
+     *
+     * @param message description of the error.
+     */
+    constructor(message: string) {
+        super(message);
+    }
+}

--- a/src/JDNConvertibleCalendarError.ts
+++ b/src/JDNConvertibleCalendarError.ts
@@ -1,3 +1,23 @@
+/*
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of JDNConvertibleCalendar.
+ *
+ * JDNConvertibleCalendar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JDNConvertibleCalendar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 /**
  * Represents an error that occurred when using `JDNConvertibleCalendarModule`.
  */

--- a/src/JDNPeriod.ts
+++ b/src/JDNPeriod.ts
@@ -1,3 +1,23 @@
+/*
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of JDNConvertibleCalendar.
+ *
+ * JDNConvertibleCalendar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JDNConvertibleCalendar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { JDNConvertibleCalendarError } from './JDNConvertibleCalendarError';
 import { TypeDefinitionsModule } from './TypeDefinitions';
 import { Utils } from './Utils';

--- a/src/JDNPeriod.ts
+++ b/src/JDNPeriod.ts
@@ -1,0 +1,33 @@
+import { JDNConvertibleCalendarError } from './JDNConvertibleCalendarError';
+import { TypeDefinitionsModule } from './TypeDefinitions';
+import { Utils } from './Utils';
+
+/**
+ * Represents a period as two JDNs.
+ */
+export class JDNPeriod {
+
+    /**
+     * Indicates if the date is exact (day precision).
+     */
+    public readonly exactDate: Boolean;
+
+    /**
+     *
+     * @param periodStart start of the period.
+     * @param periodEnd End of the period.
+     */
+    constructor(public readonly periodStart: TypeDefinitionsModule.JDN, public readonly periodEnd: TypeDefinitionsModule.JDN) {
+
+        // check that periodStart equals or is before periodEnd
+        if (periodStart > periodEnd) throw new JDNConvertibleCalendarError(`start of a JDNPeriod must not be greater than its end`);
+
+        // check that given arguments are integers (JDNs have no fractions)
+        if (!(Utils.isInteger(periodStart) && Utils.isInteger(periodEnd))) {
+            throw new JDNConvertibleCalendarError('JDNs are expected to be integers');
+        }
+
+        this.exactDate = (periodStart === periodEnd);
+
+    }
+}

--- a/src/TypeDefinitions.ts
+++ b/src/TypeDefinitions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
  * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
  *
  * This file is part of JDNConvertibleCalendar.

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,3 +1,23 @@
+/*
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of JDNConvertibleCalendar.
+ *
+ * JDNConvertibleCalendar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JDNConvertibleCalendar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export namespace Utils {
 
     /**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,0 +1,15 @@
+export namespace Utils {
+
+    /**
+     * Checks if a given number is an integer.
+     *
+     * @param num number to check for.
+     * @returns true if the given number is an integer, returns false otherwise.
+     */
+    export const isInteger = (num: number): boolean => {
+
+        // https://stackoverflow.com/questions/3885817/how-do-i-check-that-a-number-is-float-or-integer
+        return num % 1 === 0;
+    };
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,28 +4,4 @@ export { JDNPeriod } from "./JDNPeriod";
 export { JDNConvertibleCalendar, GregorianCalendarDate, IslamicCalendarDate, JulianCalendarDate } from "./JDNConvertibleCalendar";
 
 import { JDNConvertibleConversionModule } from './JDNCalendarConversion';
-
-import gregorianToJDC = JDNConvertibleConversionModule.gregorianToJDC;
-import gregorianToJDN = JDNConvertibleConversionModule.gregorianToJDN;
-import julianToJDC = JDNConvertibleConversionModule.julianToJDC;
-import julianToJDN = JDNConvertibleConversionModule.julianToJDN;
-import islamicToJDC = JDNConvertibleConversionModule.islamicToJDC;
-import islamicToJDN = JDNConvertibleConversionModule.islamicToJDN;
-
-import JDNToGregorian = JDNConvertibleConversionModule.JDNToGregorian;
-import JDCToGregorian = JDNConvertibleConversionModule.JDCToGregorian;
-import JDNToJulian = JDNConvertibleConversionModule.JDNToJulian;
-import JDCToJulian = JDNConvertibleConversionModule.JDCToJulian;
-import JDNToIslamic = JDNConvertibleConversionModule.JDNToIslamic;
-import JDCToIslamic = JDNConvertibleConversionModule.JDCToIslamic;
-
-import dayOfWeekFromJDC = JDNConvertibleConversionModule.dayOfWeekFromJDC
-
-export {gregorianToJDC, gregorianToJDN, julianToJDC, julianToJDN, JDNToGregorian, JDCToGregorian, JDNToJulian, JDCToJulian, islamicToJDC, islamicToJDN, JDNToIslamic, JDCToIslamic, dayOfWeekFromJDC}
-
-import { JDNConvertibleCalendarNames } from './JDNCalendarNames';
-
-import getWeekdayNames = JDNConvertibleCalendarNames.getWeekdayNames;
-import getMonthNames = JDNConvertibleCalendarNames.getMonthNames;
-
-export {getWeekdayNames, getMonthNames}
+export { JDNConvertibleConversionModule }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,5 @@ export { CalendarDate } from "./CalendarDate";
 export { CalendarPeriod } from "./CalendarPeriod";
 export { JDNPeriod } from "./JDNPeriod";
 export { JDNConvertibleCalendar, GregorianCalendarDate, IslamicCalendarDate, JulianCalendarDate } from "./JDNConvertibleCalendar";
-
-import { JDNConvertibleConversionModule } from './JDNCalendarConversion';
-export { JDNConvertibleConversionModule }
+export { JDNConvertibleConversionModule } from './JDNCalendarConversion';
+export { JDNConvertibleCalendarNames } from './JDNCalendarNames';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,31 @@
-/*
- * Copyright © 2018 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
- * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
- *
- * This file is part of JDNConvertibleCalendar.
- *
- * JDNConvertibleCalendar is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * JDNConvertibleCalendar is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
- */
+export { CalendarDate } from "./CalendarDate";
+export { CalendarPeriod } from "./CalendarPeriod";
+export { JDNPeriod } from "./JDNPeriod";
+export { JDNConvertibleCalendar, GregorianCalendarDate, IslamicCalendarDate, JulianCalendarDate } from "./JDNConvertibleCalendar";
 
-import {JDNConvertibleCalendarModule} from './JDNConvertibleCalendar';
-import {JDNConvertibleConversionModule} from './JDNCalendarConversion';
+import { JDNConvertibleConversionModule } from './JDNCalendarConversion';
 
-import CalendarDate = JDNConvertibleCalendarModule.CalendarDate;
-import JDNPeriod = JDNConvertibleCalendarModule.JDNPeriod;
-import CalendarPeriod = JDNConvertibleCalendarModule.CalendarPeriod;
-import GregorianCalendarDate = JDNConvertibleCalendarModule.GregorianCalendarDate;
-import IslamicCalendarDate = JDNConvertibleCalendarModule.IslamicCalendarDate;
-import JulianCalendarDate = JDNConvertibleCalendarModule.JulianCalendarDate;
-import JDNConvertibleCalendar = JDNConvertibleCalendarModule.JDNConvertibleCalendar;
+import gregorianToJDC = JDNConvertibleConversionModule.gregorianToJDC;
+import gregorianToJDN = JDNConvertibleConversionModule.gregorianToJDN;
+import julianToJDC = JDNConvertibleConversionModule.julianToJDC;
+import julianToJDN = JDNConvertibleConversionModule.julianToJDN;
+import islamicToJDC = JDNConvertibleConversionModule.islamicToJDC;
+import islamicToJDN = JDNConvertibleConversionModule.islamicToJDN;
+
+import JDNToGregorian = JDNConvertibleConversionModule.JDNToGregorian;
+import JDCToGregorian = JDNConvertibleConversionModule.JDCToGregorian;
+import JDNToJulian = JDNConvertibleConversionModule.JDNToJulian;
+import JDCToJulian = JDNConvertibleConversionModule.JDCToJulian;
+import JDNToIslamic = JDNConvertibleConversionModule.JDNToIslamic;
+import JDCToIslamic = JDNConvertibleConversionModule.JDCToIslamic;
+
+import dayOfWeekFromJDC = JDNConvertibleConversionModule.dayOfWeekFromJDC
+
+export {gregorianToJDC, gregorianToJDN, julianToJDC, julianToJDN, JDNToGregorian, JDCToGregorian, JDNToJulian, JDCToJulian, islamicToJDC, islamicToJDN, JDNToIslamic, JDCToIslamic, dayOfWeekFromJDC}
 
 import { JDNConvertibleCalendarNames } from './JDNCalendarNames';
 
-export {CalendarDate, JDNConvertibleCalendar, GregorianCalendarDate, IslamicCalendarDate, JulianCalendarDate, JDNPeriod, CalendarPeriod}
-export {JDNConvertibleConversionModule}
-export {JDNConvertibleCalendarNames}
+import getWeekdayNames = JDNConvertibleCalendarNames.getWeekdayNames;
+import getMonthNames = JDNConvertibleCalendarNames.getMonthNames;
+
+export {getWeekdayNames, getMonthNames}

--- a/test/conversions.ts
+++ b/test/conversions.ts
@@ -25,7 +25,20 @@ import {
     IslamicCalendarDate,
     JulianCalendarDate,
     CalendarPeriod,
-    JDNConvertibleCalendar, JDNConvertibleConversionModule
+    JDNConvertibleCalendar,
+    gregorianToJDC,
+    gregorianToJDN,
+    julianToJDC,
+    julianToJDN,
+    JDNToGregorian,
+    JDCToGregorian,
+    JDCToJulian,
+    JDNToJulian,
+    islamicToJDC,
+    islamicToJDN,
+    JDCToIslamic,
+    JDNToIslamic,
+    dayOfWeekFromJDC
 } from '../src'
 
 
@@ -80,7 +93,7 @@ describe('Conversion of a Gregorian calendar date to JDC', () => {
 
     it('convert the Gregorian Calendar date 01-01-2000 12:00 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2000, 1, 1, undefined, 0.5);
-        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2451545.0, jdc);
     });
@@ -88,35 +101,35 @@ describe('Conversion of a Gregorian calendar date to JDC', () => {
 
     it('convert the Gregorian Calendar date 27-01-1987 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1987, 1, 27, undefined, 0);
-        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2446822.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 04-10-1582 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4, undefined, 0);
-        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2299149.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 15-10-1582 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15, undefined, 0);
-        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2299160.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 22-12-(-1001) to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-1001, 12, 22, undefined, 0);
-        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(1355807.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 25-11-(-4713) to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-4713, 11, 25, undefined, 0);
-        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(0.5, jdc);
     });
@@ -129,105 +142,105 @@ describe('Conversion of a Gregorian calendar date to JDC', () => {
 describe('Conversion of a Gregorian calendar date to JDN', () => {
     it('convert the Gregorian Calendar date 01-01-2000 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2000, 1, 1);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2451545, jdn);
     });
 
     it('convert the Gregorian Calendar date 06-12-2017 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2017, 12, 6);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2458094, jdn);
     });
 
     it('convert the Gregorian Calendar date 01-01-2000 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2000, 1, 1);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2451545, jdn);
     });
 
     it('convert the Gregorian Calendar date 27-01-1987 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1987, 1, 27);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2446823, jdn);
     });
 
     it('convert the Gregorian Calendar date 19-06-1987 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1987, 6, 19);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2446966, jdn);
     });
 
     it('convert the Gregorian Calendar date 27-01-1988 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1988, 1, 27);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2447188, jdn);
     });
 
     it('convert the Gregorian Calendar date 19-06-1988 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1988, 6, 19);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2447332, jdn);
     });
 
     it('convert the Gregorian Calendar date 01-01-1900 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1900, 1, 1);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2415021, jdn);
     });
 
     it('convert the Gregorian Calendar date 31-12-2016 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2016, 12, 31);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2457754, jdn);
     });
 
     it('convert the Gregorian Calendar date 01-01-1600 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1600, 1, 1);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2305448, jdn);
     });
 
     it('convert the Gregorian Calendar date 31-12-1600 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1600, 12, 31);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2305813, jdn);
     });
 
     it('convert the Gregorian Calendar date 04-10-1582 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2299150, jdn);
     });
 
     it('convert the Gregorian Calendar date 15-10-1582 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2299161, jdn);
     });
 
     it('convert the Gregorian Calendar date 22-12-(-1001) to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-1001, 12, 22);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(1355808, jdn);
     });
 
     it('convert the Gregorian Calendar date 24-11-(-4713) to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-4713, 11, 24);
-        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(0, jdn);
     });
@@ -241,35 +254,35 @@ describe('Conversion of a  Julian calendar date to JDC', () => {
 
     it('convert the Julian Calendar date 04-10-1582 to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4, undefined, 0.3);
-        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
+        const jdc: number = julianToJDC(julianCalendarDate);
 
         checkJDC(2299159.8, jdc);
     });
 
     it('convert the Julian Calendar date 15-10-1582 to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15, undefined, 0.3);
-        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
+        const jdc: number = julianToJDC(julianCalendarDate);
 
         checkJDC(2299170.8, jdc);
     });
 
     it('convert the Julian Calendar date 10-04-837 to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(837, 4, 10, undefined, 0.3);
-        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
+        const jdc: number = julianToJDC(julianCalendarDate);
 
         checkJDC(2026871.8, jdc);
     });
 
     it('convert the Julian Calendar date 01-01-(-1000) to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1000, 1, 1, undefined, 0.9);
-        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
+        const jdc: number = julianToJDC(julianCalendarDate);
 
         checkJDC(1355808.4, jdc);
     });
 
     it('convert the Julian Calendar date 17-08-(-1001) to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1001, 8, 17, undefined, 0.9);
-        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
+        const jdc: number = julianToJDC(julianCalendarDate);
 
         checkJDC(1355671.4, jdc);
     });
@@ -277,7 +290,7 @@ describe('Conversion of a  Julian calendar date to JDC', () => {
 
     it('convert the Julian Calendar date 01-01-(-4712) to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-4712, 1, 1, undefined, 0.5);
-        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
+        const jdc: number = julianToJDC(julianCalendarDate);
 
         checkJDC(0, jdc);
     });
@@ -292,35 +305,35 @@ describe('Conversion of a Julian calendar date to JDN', () => {
 
     it('convert the Julian Calendar date 04-10-1582 to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4);
-        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn: number = julianToJDN(julianCalendarDate);
 
         checkJDN(2299160, jdn);
     });
 
     it('convert the Julian Calendar date 15-10-1582 to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15);
-        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn: number = julianToJDN(julianCalendarDate);
 
         checkJDN(2299171, jdn);
     });
 
     it('convert the Julian Calendar date 10-04-837 to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(837, 4, 10);
-        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn: number = julianToJDN(julianCalendarDate);
 
         checkJDN(2026872, jdn);
     });
 
     it('convert the Julian Calendar date 01-01-(-1000) to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1000, 1, 1);
-        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn: number = julianToJDN(julianCalendarDate);
 
         checkJDN(1355808, jdn);
     });
 
     it('convert the Julian Calendar date 17-08-(-1001) to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1001, 8, 17);
-        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn: number = julianToJDN(julianCalendarDate);
 
         checkJDN(1355671, jdn);
     });
@@ -328,7 +341,7 @@ describe('Conversion of a Julian calendar date to JDN', () => {
 
     it('convert the Julian Calendar date 01-01-(-4712) to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-4712, 1, 1);
-        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn: number = julianToJDN(julianCalendarDate);
 
         checkJDN(0, jdn);
     });
@@ -339,7 +352,7 @@ describe('Conversion of a Julian calendar date to JDN', () => {
 //
 describe('Conversion JDN to Gregorian calendar', () => {
     it('convert the JDN 2458094 back to the Gregorian Calendar date 06-12-2017', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2458094);
+        const gregorianCalendarDate = JDNToGregorian(2458094);
 
         const expectedDate = new CalendarDate(2017, 12, 6);
 
@@ -347,7 +360,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2458094 back to the Gregorian Calendar date 06-12-2017', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2458093.5);
+        const gregorianCalendarDate = JDNToGregorian(2458093.5);
 
         const expectedDate = new CalendarDate(2017, 12, 6);
 
@@ -355,7 +368,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2458094 back to the Gregorian Calendar date 06-12-2017', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2458094.4999);
+        const gregorianCalendarDate = JDNToGregorian(2458094.4999);
 
         const expectedDate = new CalendarDate(2017, 12, 6);
 
@@ -363,7 +376,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2457754 back to the Gregorian Calendar date 31-12-2016', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2457754);
+        const gregorianCalendarDate = JDNToGregorian(2457754);
 
         const expectedDate = new CalendarDate(2016, 12, 31);
 
@@ -371,7 +384,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2299150 back to the Gregorian Calendar date 04-10-1582', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2299150);
+        const gregorianCalendarDate = JDNToGregorian(2299150);
 
         const expectedDate = new CalendarDate(1582, 10, 4);
 
@@ -379,7 +392,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2299161 back to the Gregorian Calendar date 15-10-1582', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2299161);
+        const gregorianCalendarDate = JDNToGregorian(2299161);
 
         const expectedDate = new CalendarDate(1582, 10, 15);
 
@@ -387,7 +400,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 1355808 back to the Gregorian Calendar date 22-12-(-1001)', () => {
-        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(1355808);
+        const gregorianCalendarDate = JDNToGregorian(1355808);
 
         const expectedDate = new CalendarDate(-1001, 12, 22);
 
@@ -402,7 +415,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
 describe('Conversion JDN to Julian calendar', () => {
 
     it('convert the JDN 2299160 back to the Julian Calendar date 04-10-1582', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2299160);
+        const julianCalendarDate = JDNToJulian(2299160);
 
         const expectedDate = new CalendarDate(1582, 10, 4);
 
@@ -410,7 +423,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 2299171 back to the Julian Calendar date 15-10-1582', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2299171);
+        const julianCalendarDate = JDNToJulian(2299171);
 
         const expectedDate = new CalendarDate(1582, 10, 15);
 
@@ -418,7 +431,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 2026872 back to the Julian Calendar date 10-04-837', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2026872);
+        const julianCalendarDate = JDNToJulian(2026872);
 
         const expectedDate = new CalendarDate(837, 4, 10);
 
@@ -426,7 +439,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 1355808 back to the Julian Calendar date 01-01-(-1000)', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(1355808);
+        const julianCalendarDate = JDNToJulian(1355808);
 
         const expectedDate = new CalendarDate(-1000, 1, 1);
 
@@ -434,7 +447,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 1355671 back to the Julian Calendar date 17-08-(-1001)', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(1355671);
+        const julianCalendarDate = JDNToJulian(1355671);
 
         const expectedDate = new CalendarDate(-1001, 8, 17);
 
@@ -446,127 +459,127 @@ describe('Conversion JDN to Julian calendar', () => {
 describe('Islamic to JDC', () => {
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458093.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17));
+        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17));
 
         checkJDC(2458093.5, jdc);
     });
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458093.6', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.1));
+        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.1));
 
         checkJDC(2458093.6, jdc);
     });
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458094', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.5));
+        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.5));
 
         checkJDC(2458094, jdc);
     });
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458094', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.9));
+        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.9));
 
         checkJDC(2458094.4, jdc);
     });
 
     it('convert the Islamic Calendar date 01-01-1421 to JDC 2451640.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1421, 1, 1));
+        const jdc = islamicToJDC(new CalendarDate(1421, 1, 1));
 
         checkJDC(2451640.5, jdc);
     });
 
     it('convert the Islamic Calendar date 29-12-0000 to JDC 1948438.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(0, 12, 29));
+        const jdc = islamicToJDC(new CalendarDate(0, 12, 29));
 
         checkJDC(1948438.5, jdc);
     });
 
     it('convert the Islamic Calendar date 01-01-0001 to JDC 1948439.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1, 1, 1));
+        const jdc = islamicToJDC(new CalendarDate(1, 1, 1));
 
         checkJDC(1948439.5, jdc);
     });
 
     it('convert the Islamic Calendar date 25-01-0104 to JDC 1984963.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(104, 1, 25));
+        const jdc = islamicToJDC(new CalendarDate(104, 1, 25));
 
         checkJDC(1984963.5, jdc);
     });
 
     it('convert the Islamic Calendar date 20-02-0207 to JDC 2021488.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(207, 2, 20));
+        const jdc = islamicToJDC(new CalendarDate(207, 2, 20));
 
         checkJDC(2021488.5, jdc);
     });
 
     it('convert the Islamic Calendar date 18-04-0310 to JDC 2058044.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(310, 4, 18));
+        const jdc = islamicToJDC(new CalendarDate(310, 4, 18));
 
         checkJDC(2058044.5, jdc);
     });
 
     it('convert the Islamic Calendar date 15-06-0413 to JDC 2094600.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(413, 6, 15));
+        const jdc = islamicToJDC(new CalendarDate(413, 6, 15));
 
         checkJDC(2094600.5, jdc);
     });
 
     it('convert the Islamic Calendar date 09-06-0516 to JDC 2131094.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(516, 6, 9));
+        const jdc = islamicToJDC(new CalendarDate(516, 6, 9));
 
         checkJDC(2131094.5, jdc);
     });
 
     it('convert the Islamic Calendar date 28-05-0619 to JDC 2167583.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(619, 5, 28));
+        const jdc = islamicToJDC(new CalendarDate(619, 5, 28));
 
         checkJDC(2167583.5, jdc);
     });
 
     it('convert the Islamic Calendar date 24-06-0722 to JDC 2204108.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(722, 6, 24));
+        const jdc = islamicToJDC(new CalendarDate(722, 6, 24));
 
         checkJDC(2204108.5, jdc);
     });
 
     it('convert the Islamic Calendar date 08-08-0825 to JDC 2240651.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(825, 8, 8));
+        const jdc = islamicToJDC(new CalendarDate(825, 8, 8));
 
         checkJDC(2240651.5, jdc);
     });
 
     it('convert the Islamic Calendar date 01-09-0928 to JDC 2277173.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(928, 9, 1));
+        const jdc = islamicToJDC(new CalendarDate(928, 9, 1));
 
         checkJDC(2277173.5, jdc);
     });
 
     it('convert the Islamic Calendar date 08-10-1031 to JDC 2313710.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1031, 10, 8));
+        const jdc = islamicToJDC(new CalendarDate(1031, 10, 8));
 
         checkJDC(2313710.5, jdc);
     });
 
     it('convert the Islamic Calendar date 27-11-1134 to JDC 2350257.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1134, 11, 27));
+        const jdc = islamicToJDC(new CalendarDate(1134, 11, 27));
 
         checkJDC(2350257.5, jdc);
     });
 
     it('convert the Islamic Calendar date 29-12-1237 to JDC 2386789.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1237, 12, 29));
+        const jdc = islamicToJDC(new CalendarDate(1237, 12, 29));
 
         checkJDC(2386789.5, jdc);
     });
 
     it('convert the Islamic Calendar date 25-03-1341 to JDC 2423373.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1341, 3, 25));
+        const jdc = islamicToJDC(new CalendarDate(1341, 3, 25));
 
         checkJDC(2423373.5, jdc);
     });
 
     it('convert the Islamic Calendar date 20-07-1420 to JDC 2451481.5', () => {
-        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1420, 7, 20));
+        const jdc = islamicToJDC(new CalendarDate(1420, 7, 20));
 
         checkJDC(2451481.5, jdc);
     });
@@ -576,109 +589,109 @@ describe('Islamic to JDC', () => {
 describe('Islamic to JDN', () => {
 
     it('convert the Islamic Calendar date 17-03-1439 to JDN 2458094', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1439, 3, 17));
+        const jdn = islamicToJDN(new CalendarDate(1439, 3, 17));
 
         checkJDN(2458094, jdn);
     });
 
     it('convert the Islamic Calendar date 01-01-1421 to JDN 2451641', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1421, 1, 1));
+        const jdn = islamicToJDN(new CalendarDate(1421, 1, 1));
 
         checkJDN(2451641, jdn);
     });
 
     it('convert the Islamic Calendar date 29-12-0000 to JDN 1948439', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(0, 12, 29));
+        const jdn = islamicToJDN(new CalendarDate(0, 12, 29));
 
         checkJDN(1948439, jdn);
     });
 
     it('convert the Islamic Calendar date 01-01-0001 to JDN 1948440', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1, 1, 1));
+        const jdn = islamicToJDN(new CalendarDate(1, 1, 1));
 
         checkJDN(1948440, jdn);
     });
 
     it('convert the Islamic Calendar date 25-01-0104 to JDN 1984964', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(104, 1, 25));
+        const jdn = islamicToJDN(new CalendarDate(104, 1, 25));
 
         checkJDN(1984964, jdn);
     });
 
     it('convert the Islamic Calendar date 20-02-0207 to JDN 2021489', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(207, 2, 20));
+        const jdn = islamicToJDN(new CalendarDate(207, 2, 20));
 
         checkJDN(2021489, jdn);
     });
 
     it('convert the Islamic Calendar date 18-04-0310 to JDN 2058045', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(310, 4, 18));
+        const jdn = islamicToJDN(new CalendarDate(310, 4, 18));
 
         checkJDN(2058045, jdn);
     });
 
     it('convert the Islamic Calendar date 15-06-0413 to JDN 2094601', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(413, 6, 15));
+        const jdn = islamicToJDN(new CalendarDate(413, 6, 15));
 
         checkJDN(2094601, jdn);
     });
 
     it('convert the Islamic Calendar date 09-06-0516 to JDN 2131095', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(516, 6, 9));
+        const jdn = islamicToJDN(new CalendarDate(516, 6, 9));
 
         checkJDN(2131095, jdn);
     });
 
     it('convert the Islamic Calendar date 28-05-0619 to JDN 2167584', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(619, 5, 28));
+        const jdn = islamicToJDN(new CalendarDate(619, 5, 28));
 
         checkJDN(2167584, jdn);
     });
 
     it('convert the Islamic Calendar date 24-06-0722 to JDN 2204109', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(722, 6, 24));
+        const jdn = islamicToJDN(new CalendarDate(722, 6, 24));
 
         checkJDN(2204109, jdn);
     });
 
     it('convert the Islamic Calendar date 08-08-0825 to JDN 2240652', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(825, 8, 8));
+        const jdn = islamicToJDN(new CalendarDate(825, 8, 8));
 
         checkJDN(2240652, jdn);
     });
 
     it('convert the Islamic Calendar date 01-09-0928 to JDN 2277174', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(928, 9, 1));
+        const jdn = islamicToJDN(new CalendarDate(928, 9, 1));
 
         checkJDN(2277174, jdn);
     });
 
     it('convert the Islamic Calendar date 08-10-1031 to JDN 2313711', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1031, 10, 8));
+        const jdn = islamicToJDN(new CalendarDate(1031, 10, 8));
 
         checkJDN(2313711, jdn);
     });
 
     it('convert the Islamic Calendar date 27-11-1134 to JDN 2350258', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1134, 11, 27));
+        const jdn = islamicToJDN(new CalendarDate(1134, 11, 27));
 
         checkJDN(2350258, jdn);
     });
 
     it('convert the Islamic Calendar date 29-12-1237 to JDN 2386790', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1237, 12, 29));
+        const jdn = islamicToJDN(new CalendarDate(1237, 12, 29));
 
         checkJDN(2386790, jdn);
     });
 
     it('convert the Islamic Calendar date 25-03-1341 to JDN 2423374', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1341, 3, 25));
+        const jdn = islamicToJDN(new CalendarDate(1341, 3, 25));
 
         checkJDN(2423374, jdn);
     });
 
     it('convert the Islamic Calendar date 20-07-1420 to JDN 2451482', () => {
-        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1420, 7, 20));
+        const jdn = islamicToJDN(new CalendarDate(1420, 7, 20));
 
         checkJDN(2451482, jdn);
     });
@@ -688,7 +701,7 @@ describe('Islamic to JDN', () => {
 describe('JDC to Islamic', () => {
 
     it('convert the JDC 2458093.5 to the Islamic Calendar date 17-03-1439', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2458093.5);
+        const islamicCalendarDate = JDCToIslamic(2458093.5);
 
         const expectedDate = new CalendarDate(1439, 3, 17);
 
@@ -697,7 +710,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2458093.6 to the Islamic Calendar date 17-03-1439', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2458093.6);
+        const islamicCalendarDate = JDCToIslamic(2458093.6);
 
         const expectedDate = new CalendarDate(1439, 3, 17, undefined, 0.1);
 
@@ -716,7 +729,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2448481.5 to the Islamic Calendar date 02-02-1412', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2448481.5);
+        const islamicCalendarDate = JDCToIslamic(2448481.5);
 
         const expectedDate = new CalendarDate(1412, 2, 2);
 
@@ -724,7 +737,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 1948438.5 to the Islamic Calendar date 29-12-0000', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(1948438.5);
+        const islamicCalendarDate = JDCToIslamic(1948438.5);
 
         const expectedDate = new CalendarDate(0, 12, 29);
 
@@ -732,7 +745,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 1948439.5 to the Islamic Calendar date 01-01-0001', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(1948439.5);
+        const islamicCalendarDate = JDCToIslamic(1948439.5);
 
         const expectedDate = new CalendarDate(1, 1, 1);
 
@@ -740,7 +753,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 1984963.5 to the Islamic Calendar date 25-01-0104', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(1984963.5);
+        const islamicCalendarDate = JDCToIslamic(1984963.5);
 
         const expectedDate = new CalendarDate(104, 1, 25);
 
@@ -748,7 +761,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2021488.5 to the Islamic Calendar date 20-02-0207', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2021488.5);
+        const islamicCalendarDate = JDCToIslamic(2021488.5);
 
         const expectedDate = new CalendarDate(207, 2, 20);
 
@@ -756,7 +769,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2058044.5 to the Islamic Calendar date 18-04-0310', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2058044.5);
+        const islamicCalendarDate = JDCToIslamic(2058044.5);
 
         const expectedDate = new CalendarDate(310, 4, 18);
 
@@ -764,7 +777,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2094600.5 to the Islamic Calendar date 15-06-0413', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2094600.5);
+        const islamicCalendarDate = JDCToIslamic(2094600.5);
 
         const expectedDate = new CalendarDate(413, 6, 15);
 
@@ -772,7 +785,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2131094.5 to the Islamic Calendar date 09-06-0516', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2131094.5);
+        const islamicCalendarDate = JDCToIslamic(2131094.5);
 
         const expectedDate = new CalendarDate(516, 6, 9);
 
@@ -780,7 +793,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2167583.5 to the Islamic Calendar date 28-05-0619', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2167583.5);
+        const islamicCalendarDate = JDCToIslamic(2167583.5);
 
         const expectedDate = new CalendarDate(619, 5, 28);
 
@@ -788,7 +801,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2204108.5 to the Islamic Calendar date 24-06-0722', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2204108.5);
+        const islamicCalendarDate = JDCToIslamic(2204108.5);
 
         const expectedDate = new CalendarDate(722, 6, 24);
 
@@ -796,7 +809,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2240651.5 to the Islamic Calendar date 08-08-0825', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2240651.5);
+        const islamicCalendarDate = JDCToIslamic(2240651.5);
 
         const expectedDate = new CalendarDate(825, 8, 8);
 
@@ -804,7 +817,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2277173.5 to the Islamic Calendar date 01-09-0928', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2277173.5);
+        const islamicCalendarDate = JDCToIslamic(2277173.5);
 
         const expectedDate = new CalendarDate(928, 9, 1);
 
@@ -812,7 +825,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2313710.5 to the Islamic Calendar date 08-10-1031', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2313710.5);
+        const islamicCalendarDate = JDCToIslamic(2313710.5);
 
         const expectedDate = new CalendarDate(1031, 10, 8);
 
@@ -820,7 +833,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2350257.5 to the Islamic Calendar date 27-11-1134', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2350257.5);
+        const islamicCalendarDate = JDCToIslamic(2350257.5);
 
         const expectedDate = new CalendarDate(1134, 11, 27);
 
@@ -828,7 +841,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2386789.5 to the Islamic Calendar date 29-12-1237', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2386789.5);
+        const islamicCalendarDate = JDCToIslamic(2386789.5);
 
         const expectedDate = new CalendarDate(1237, 12, 29);
 
@@ -836,7 +849,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2423373.5 to the Islamic Calendar date 25-03-1341', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2423373.5);
+        const islamicCalendarDate = JDCToIslamic(2423373.5);
 
         const expectedDate = new CalendarDate(1341, 3, 25);
 
@@ -844,7 +857,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2451481.5 to the Islamic Calendar date 20-07-1420', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2451481.5);
+        const islamicCalendarDate = JDCToIslamic(2451481.5);
 
         const expectedDate = new CalendarDate(1420, 7, 20);
 
@@ -856,7 +869,7 @@ describe('JDC to Islamic', () => {
 describe('JDN to Islamic', () => {
 
     it('convert the JDN 2458094 to the Islamic Calendar date 17-03-1439', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2458094);
+        const islamicCalendarDate = JDNToIslamic(2458094);
 
         const expectedDate = new CalendarDate(1439, 3, 17);
 
@@ -864,7 +877,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 1948439 to the Islamic Calendar date 29-12-0000', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(1948439);
+        const islamicCalendarDate = JDNToIslamic(1948439);
 
         const expectedDate = new CalendarDate(0, 12, 29);
 
@@ -872,7 +885,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 1948440 to the Islamic Calendar date 01-01-0001', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(1948440);
+        const islamicCalendarDate = JDNToIslamic(1948440);
 
         const expectedDate = new CalendarDate(1, 1, 1);
 
@@ -880,7 +893,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 1984964 to the Islamic Calendar date 25-01-0104', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(1984964);
+        const islamicCalendarDate = JDNToIslamic(1984964);
 
         const expectedDate = new CalendarDate(104, 1, 25);
 
@@ -888,7 +901,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2021489 to the Islamic Calendar date 20-02-0207', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2021489);
+        const islamicCalendarDate = JDNToIslamic(2021489);
 
         const expectedDate = new CalendarDate(207, 2, 20);
 
@@ -896,7 +909,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2058045 to the Islamic Calendar date 18-04-0310', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2058045);
+        const islamicCalendarDate = JDNToIslamic(2058045);
 
         const expectedDate = new CalendarDate(310, 4, 18);
 
@@ -904,7 +917,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2094601 to the Islamic Calendar date 15-06-0413', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2094601);
+        const islamicCalendarDate = JDNToIslamic(2094601);
 
         const expectedDate = new CalendarDate(413, 6, 15);
 
@@ -912,7 +925,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2131095 to the Islamic Calendar date 09-06-0516', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2131095);
+        const islamicCalendarDate = JDNToIslamic(2131095);
 
         const expectedDate = new CalendarDate(516, 6, 9);
 
@@ -920,7 +933,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2167584 to the Islamic Calendar date 28-05-0619', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2167584);
+        const islamicCalendarDate = JDNToIslamic(2167584);
 
         const expectedDate = new CalendarDate(619, 5, 28);
 
@@ -928,7 +941,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2204109 to the Islamic Calendar date 24-06-0722', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2204109);
+        const islamicCalendarDate = JDNToIslamic(2204109);
 
         const expectedDate = new CalendarDate(722, 6, 24);
 
@@ -936,7 +949,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2240652 to the Islamic Calendar date 08-08-0825', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2240652);
+        const islamicCalendarDate = JDNToIslamic(2240652);
 
         const expectedDate = new CalendarDate(825, 8, 8);
 
@@ -944,7 +957,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2277174 to the Islamic Calendar date 01-09-0928', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2277174);
+        const islamicCalendarDate = JDNToIslamic(2277174);
 
         const expectedDate = new CalendarDate(928, 9, 1);
 
@@ -952,7 +965,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2313711 to the Islamic Calendar date 08-10-1031', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2313711);
+        const islamicCalendarDate = JDNToIslamic(2313711);
 
         const expectedDate = new CalendarDate(1031, 10, 8);
 
@@ -960,7 +973,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2350258 to the Islamic Calendar date 27-11-1134', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2350258);
+        const islamicCalendarDate = JDNToIslamic(2350258);
 
         const expectedDate = new CalendarDate(1134, 11, 27);
 
@@ -968,7 +981,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2386790 to the Islamic Calendar date 29-12-1237', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2386790);
+        const islamicCalendarDate = JDNToIslamic(2386790);
 
         const expectedDate = new CalendarDate(1237, 12, 29);
 
@@ -976,7 +989,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2423374 to the Islamic Calendar date 25-03-1341', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2423374);
+        const islamicCalendarDate = JDNToIslamic(2423374);
 
         const expectedDate = new CalendarDate(1341, 3, 25);
 
@@ -984,7 +997,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2451482 to the Islamic Calendar date 20-07-1420', () => {
-        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2451482);
+        const islamicCalendarDate = JDNToIslamic(2451482);
 
         const expectedDate = new CalendarDate(1420, 7, 20);
 
@@ -1002,13 +1015,13 @@ describe('JDN conversions to Julian calendar and back', () => {
     it('convert the Julian Calendar date 2017-11-23 to JDN', () => {
 
         const julianCalendarDate: CalendarDate = new CalendarDate(2017, 11, 23);
-        const jdn = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn = julianToJDN(julianCalendarDate);
 
         checkJDN(2458094, jdn);
     });
 
     it('convert the JDN 2458094 back to the Julian Calendar date 23-11-2017', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2458094);
+        const julianCalendarDate = JDNToJulian(2458094);
 
         const expectedDate = new CalendarDate(2017, 11, 23);
 
@@ -1018,13 +1031,13 @@ describe('JDN conversions to Julian calendar and back', () => {
     it('convert the Julian Calendar date 1582-10-15 to JDN', () => {
 
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15);
-        const jdn = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn = julianToJDN(julianCalendarDate);
 
         checkJDN(2299171, jdn);
     });
 
     it('convert the JDN 2299171 back to the Julian Calendar date 15-10-1582', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2299171);
+        const julianCalendarDate = JDNToJulian(2299171);
 
         const expectedDate = new CalendarDate(1582, 10, 15);
 
@@ -1034,13 +1047,13 @@ describe('JDN conversions to Julian calendar and back', () => {
     it('convert the Julian Calendar date (-1000)-01-01 to JDN', () => {
 
         const julianCalendarDate: CalendarDate = new CalendarDate(-1000, 1, 1);
-        const jdn = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
+        const jdn = julianToJDN(julianCalendarDate);
 
         checkJDN(1355808, jdn);
     });
 
     it('convert the JDN 1355808 back to the Julian Calendar date 01-01-(-1000)', () => {
-        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(1355808);
+        const julianCalendarDate = JDNToJulian(1355808);
 
         const expectedDate = new CalendarDate(-1000, 1, 1);
 
@@ -2191,7 +2204,7 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
     it('create the JDN for the Julian calendar date 15-03-44 BCE when Caesar was murdered and convert it to Gregorian', () => {
 
         // assassination of Caesar: Julian calendar date 15-03-44 BCE
-        const jdn = JDNConvertibleConversionModule.julianToJDN(new CalendarDate(-43, 3, 15));
+        const jdn = julianToJDN(new CalendarDate(-43, 3, 15));
 
         checkJDN(1705426, jdn);
 
@@ -2546,15 +2559,15 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
 describe('Determine day of week from JDC', () => {
 
     it('Test for day of the week from JDC 2434923.5 to 3 (Wednesday)', () => {
-        assert.strictEqual(JDNConvertibleConversionModule.dayOfWeekFromJDC(2434923.5), 3);
+        assert.strictEqual(dayOfWeekFromJDC(2434923.5), 3);
     });
 
     it('Test for day of the week from JDC 2434924.0 to 3 (Wednesday)', () => {
-        assert.strictEqual(JDNConvertibleConversionModule.dayOfWeekFromJDC(2434924.0), 3);
+        assert.strictEqual(dayOfWeekFromJDC(2434924.0), 3);
     });
 
     it('Test for day of the week from JDC 2434924.4999 to 3 (Wednesday)', () => {
-        assert.strictEqual(JDNConvertibleConversionModule.dayOfWeekFromJDC(2434924.4999), 3);
+        assert.strictEqual(dayOfWeekFromJDC(2434924.4999), 3);
     });
 });
 

--- a/test/conversions.ts
+++ b/test/conversions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
  * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
  *
  * This file is part of JDNConvertibleCalendar.

--- a/test/conversions.ts
+++ b/test/conversions.ts
@@ -18,29 +18,11 @@
  * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-    CalendarDate,
-    JDNPeriod,
-    GregorianCalendarDate,
-    IslamicCalendarDate,
-    JulianCalendarDate,
-    CalendarPeriod,
-    JDNConvertibleCalendar,
-    gregorianToJDC,
-    gregorianToJDN,
-    julianToJDC,
-    julianToJDN,
-    JDNToGregorian,
-    JDCToGregorian,
-    JDCToJulian,
-    JDNToJulian,
-    islamicToJDC,
-    islamicToJDN,
-    JDCToIslamic,
-    JDNToIslamic,
-    dayOfWeekFromJDC
-} from '../src'
-
+import { CalendarDate } from '../src/CalendarDate';
+import { JDNConvertibleConversionModule } from '../src/JDNCalendarConversion';
+import { GregorianCalendarDate, JulianCalendarDate, IslamicCalendarDate, JDNConvertibleCalendar } from '../src/JDNConvertibleCalendar';
+import { JDNPeriod } from '../src/JDNPeriod';
+import { CalendarPeriod } from '../src/CalendarPeriod';
 
 let assert = require('assert');
 
@@ -93,7 +75,7 @@ describe('Conversion of a Gregorian calendar date to JDC', () => {
 
     it('convert the Gregorian Calendar date 01-01-2000 12:00 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2000, 1, 1, undefined, 0.5);
-        const jdc: number = gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2451545.0, jdc);
     });
@@ -101,35 +83,35 @@ describe('Conversion of a Gregorian calendar date to JDC', () => {
 
     it('convert the Gregorian Calendar date 27-01-1987 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1987, 1, 27, undefined, 0);
-        const jdc: number = gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2446822.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 04-10-1582 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4, undefined, 0);
-        const jdc: number = gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2299149.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 15-10-1582 to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15, undefined, 0);
-        const jdc: number = gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(2299160.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 22-12-(-1001) to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-1001, 12, 22, undefined, 0);
-        const jdc: number = gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(1355807.5, jdc);
     });
 
     it('convert the Gregorian Calendar date 25-11-(-4713) to JDC', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-4713, 11, 25, undefined, 0);
-        const jdc: number = gregorianToJDC(gregorianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.gregorianToJDC(gregorianCalendarDate);
 
         checkJDC(0.5, jdc);
     });
@@ -142,105 +124,105 @@ describe('Conversion of a Gregorian calendar date to JDC', () => {
 describe('Conversion of a Gregorian calendar date to JDN', () => {
     it('convert the Gregorian Calendar date 01-01-2000 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2000, 1, 1);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2451545, jdn);
     });
 
     it('convert the Gregorian Calendar date 06-12-2017 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2017, 12, 6);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2458094, jdn);
     });
 
     it('convert the Gregorian Calendar date 01-01-2000 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2000, 1, 1);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2451545, jdn);
     });
 
     it('convert the Gregorian Calendar date 27-01-1987 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1987, 1, 27);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2446823, jdn);
     });
 
     it('convert the Gregorian Calendar date 19-06-1987 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1987, 6, 19);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2446966, jdn);
     });
 
     it('convert the Gregorian Calendar date 27-01-1988 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1988, 1, 27);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2447188, jdn);
     });
 
     it('convert the Gregorian Calendar date 19-06-1988 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1988, 6, 19);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2447332, jdn);
     });
 
     it('convert the Gregorian Calendar date 01-01-1900 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1900, 1, 1);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2415021, jdn);
     });
 
     it('convert the Gregorian Calendar date 31-12-2016 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(2016, 12, 31);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2457754, jdn);
     });
 
     it('convert the Gregorian Calendar date 01-01-1600 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1600, 1, 1);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2305448, jdn);
     });
 
     it('convert the Gregorian Calendar date 31-12-1600 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1600, 12, 31);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2305813, jdn);
     });
 
     it('convert the Gregorian Calendar date 04-10-1582 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2299150, jdn);
     });
 
     it('convert the Gregorian Calendar date 15-10-1582 to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(2299161, jdn);
     });
 
     it('convert the Gregorian Calendar date 22-12-(-1001) to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-1001, 12, 22);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(1355808, jdn);
     });
 
     it('convert the Gregorian Calendar date 24-11-(-4713) to JDN', () => {
         const gregorianCalendarDate: CalendarDate = new CalendarDate(-4713, 11, 24);
-        const jdn: number = gregorianToJDN(gregorianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.gregorianToJDN(gregorianCalendarDate);
 
         checkJDN(0, jdn);
     });
@@ -254,35 +236,35 @@ describe('Conversion of a  Julian calendar date to JDC', () => {
 
     it('convert the Julian Calendar date 04-10-1582 to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4, undefined, 0.3);
-        const jdc: number = julianToJDC(julianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
 
         checkJDC(2299159.8, jdc);
     });
 
     it('convert the Julian Calendar date 15-10-1582 to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15, undefined, 0.3);
-        const jdc: number = julianToJDC(julianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
 
         checkJDC(2299170.8, jdc);
     });
 
     it('convert the Julian Calendar date 10-04-837 to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(837, 4, 10, undefined, 0.3);
-        const jdc: number = julianToJDC(julianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
 
         checkJDC(2026871.8, jdc);
     });
 
     it('convert the Julian Calendar date 01-01-(-1000) to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1000, 1, 1, undefined, 0.9);
-        const jdc: number = julianToJDC(julianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
 
         checkJDC(1355808.4, jdc);
     });
 
     it('convert the Julian Calendar date 17-08-(-1001) to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1001, 8, 17, undefined, 0.9);
-        const jdc: number = julianToJDC(julianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
 
         checkJDC(1355671.4, jdc);
     });
@@ -290,7 +272,7 @@ describe('Conversion of a  Julian calendar date to JDC', () => {
 
     it('convert the Julian Calendar date 01-01-(-4712) to JDC', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-4712, 1, 1, undefined, 0.5);
-        const jdc: number = julianToJDC(julianCalendarDate);
+        const jdc: number = JDNConvertibleConversionModule.julianToJDC(julianCalendarDate);
 
         checkJDC(0, jdc);
     });
@@ -305,35 +287,35 @@ describe('Conversion of a Julian calendar date to JDN', () => {
 
     it('convert the Julian Calendar date 04-10-1582 to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 4);
-        const jdn: number = julianToJDN(julianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(2299160, jdn);
     });
 
     it('convert the Julian Calendar date 15-10-1582 to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15);
-        const jdn: number = julianToJDN(julianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(2299171, jdn);
     });
 
     it('convert the Julian Calendar date 10-04-837 to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(837, 4, 10);
-        const jdn: number = julianToJDN(julianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(2026872, jdn);
     });
 
     it('convert the Julian Calendar date 01-01-(-1000) to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1000, 1, 1);
-        const jdn: number = julianToJDN(julianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(1355808, jdn);
     });
 
     it('convert the Julian Calendar date 17-08-(-1001) to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-1001, 8, 17);
-        const jdn: number = julianToJDN(julianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(1355671, jdn);
     });
@@ -341,7 +323,7 @@ describe('Conversion of a Julian calendar date to JDN', () => {
 
     it('convert the Julian Calendar date 01-01-(-4712) to JDN', () => {
         const julianCalendarDate: CalendarDate = new CalendarDate(-4712, 1, 1);
-        const jdn: number = julianToJDN(julianCalendarDate);
+        const jdn: number = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(0, jdn);
     });
@@ -352,7 +334,7 @@ describe('Conversion of a Julian calendar date to JDN', () => {
 //
 describe('Conversion JDN to Gregorian calendar', () => {
     it('convert the JDN 2458094 back to the Gregorian Calendar date 06-12-2017', () => {
-        const gregorianCalendarDate = JDNToGregorian(2458094);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2458094);
 
         const expectedDate = new CalendarDate(2017, 12, 6);
 
@@ -360,7 +342,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2458094 back to the Gregorian Calendar date 06-12-2017', () => {
-        const gregorianCalendarDate = JDNToGregorian(2458093.5);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2458093.5);
 
         const expectedDate = new CalendarDate(2017, 12, 6);
 
@@ -368,7 +350,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2458094 back to the Gregorian Calendar date 06-12-2017', () => {
-        const gregorianCalendarDate = JDNToGregorian(2458094.4999);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2458094.4999);
 
         const expectedDate = new CalendarDate(2017, 12, 6);
 
@@ -376,7 +358,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2457754 back to the Gregorian Calendar date 31-12-2016', () => {
-        const gregorianCalendarDate = JDNToGregorian(2457754);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2457754);
 
         const expectedDate = new CalendarDate(2016, 12, 31);
 
@@ -384,7 +366,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2299150 back to the Gregorian Calendar date 04-10-1582', () => {
-        const gregorianCalendarDate = JDNToGregorian(2299150);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2299150);
 
         const expectedDate = new CalendarDate(1582, 10, 4);
 
@@ -392,7 +374,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 2299161 back to the Gregorian Calendar date 15-10-1582', () => {
-        const gregorianCalendarDate = JDNToGregorian(2299161);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(2299161);
 
         const expectedDate = new CalendarDate(1582, 10, 15);
 
@@ -400,7 +382,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
     });
 
     it('convert the JDN 1355808 back to the Gregorian Calendar date 22-12-(-1001)', () => {
-        const gregorianCalendarDate = JDNToGregorian(1355808);
+        const gregorianCalendarDate = JDNConvertibleConversionModule.JDNToGregorian(1355808);
 
         const expectedDate = new CalendarDate(-1001, 12, 22);
 
@@ -415,7 +397,7 @@ describe('Conversion JDN to Gregorian calendar', () => {
 describe('Conversion JDN to Julian calendar', () => {
 
     it('convert the JDN 2299160 back to the Julian Calendar date 04-10-1582', () => {
-        const julianCalendarDate = JDNToJulian(2299160);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2299160);
 
         const expectedDate = new CalendarDate(1582, 10, 4);
 
@@ -423,7 +405,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 2299171 back to the Julian Calendar date 15-10-1582', () => {
-        const julianCalendarDate = JDNToJulian(2299171);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2299171);
 
         const expectedDate = new CalendarDate(1582, 10, 15);
 
@@ -431,7 +413,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 2026872 back to the Julian Calendar date 10-04-837', () => {
-        const julianCalendarDate = JDNToJulian(2026872);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2026872);
 
         const expectedDate = new CalendarDate(837, 4, 10);
 
@@ -439,7 +421,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 1355808 back to the Julian Calendar date 01-01-(-1000)', () => {
-        const julianCalendarDate = JDNToJulian(1355808);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(1355808);
 
         const expectedDate = new CalendarDate(-1000, 1, 1);
 
@@ -447,7 +429,7 @@ describe('Conversion JDN to Julian calendar', () => {
     });
 
     it('convert the JDN 1355671 back to the Julian Calendar date 17-08-(-1001)', () => {
-        const julianCalendarDate = JDNToJulian(1355671);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(1355671);
 
         const expectedDate = new CalendarDate(-1001, 8, 17);
 
@@ -459,127 +441,127 @@ describe('Conversion JDN to Julian calendar', () => {
 describe('Islamic to JDC', () => {
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458093.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17));
 
         checkJDC(2458093.5, jdc);
     });
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458093.6', () => {
-        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.1));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.1));
 
         checkJDC(2458093.6, jdc);
     });
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458094', () => {
-        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.5));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.5));
 
         checkJDC(2458094, jdc);
     });
 
     it('convert the Islamic Calendar date 17-03-1439 to JDC 2458094', () => {
-        const jdc = islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.9));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1439, 3, 17, undefined, 0.9));
 
         checkJDC(2458094.4, jdc);
     });
 
     it('convert the Islamic Calendar date 01-01-1421 to JDC 2451640.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1421, 1, 1));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1421, 1, 1));
 
         checkJDC(2451640.5, jdc);
     });
 
     it('convert the Islamic Calendar date 29-12-0000 to JDC 1948438.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(0, 12, 29));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(0, 12, 29));
 
         checkJDC(1948438.5, jdc);
     });
 
     it('convert the Islamic Calendar date 01-01-0001 to JDC 1948439.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1, 1, 1));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1, 1, 1));
 
         checkJDC(1948439.5, jdc);
     });
 
     it('convert the Islamic Calendar date 25-01-0104 to JDC 1984963.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(104, 1, 25));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(104, 1, 25));
 
         checkJDC(1984963.5, jdc);
     });
 
     it('convert the Islamic Calendar date 20-02-0207 to JDC 2021488.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(207, 2, 20));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(207, 2, 20));
 
         checkJDC(2021488.5, jdc);
     });
 
     it('convert the Islamic Calendar date 18-04-0310 to JDC 2058044.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(310, 4, 18));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(310, 4, 18));
 
         checkJDC(2058044.5, jdc);
     });
 
     it('convert the Islamic Calendar date 15-06-0413 to JDC 2094600.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(413, 6, 15));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(413, 6, 15));
 
         checkJDC(2094600.5, jdc);
     });
 
     it('convert the Islamic Calendar date 09-06-0516 to JDC 2131094.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(516, 6, 9));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(516, 6, 9));
 
         checkJDC(2131094.5, jdc);
     });
 
     it('convert the Islamic Calendar date 28-05-0619 to JDC 2167583.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(619, 5, 28));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(619, 5, 28));
 
         checkJDC(2167583.5, jdc);
     });
 
     it('convert the Islamic Calendar date 24-06-0722 to JDC 2204108.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(722, 6, 24));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(722, 6, 24));
 
         checkJDC(2204108.5, jdc);
     });
 
     it('convert the Islamic Calendar date 08-08-0825 to JDC 2240651.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(825, 8, 8));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(825, 8, 8));
 
         checkJDC(2240651.5, jdc);
     });
 
     it('convert the Islamic Calendar date 01-09-0928 to JDC 2277173.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(928, 9, 1));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(928, 9, 1));
 
         checkJDC(2277173.5, jdc);
     });
 
     it('convert the Islamic Calendar date 08-10-1031 to JDC 2313710.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1031, 10, 8));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1031, 10, 8));
 
         checkJDC(2313710.5, jdc);
     });
 
     it('convert the Islamic Calendar date 27-11-1134 to JDC 2350257.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1134, 11, 27));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1134, 11, 27));
 
         checkJDC(2350257.5, jdc);
     });
 
     it('convert the Islamic Calendar date 29-12-1237 to JDC 2386789.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1237, 12, 29));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1237, 12, 29));
 
         checkJDC(2386789.5, jdc);
     });
 
     it('convert the Islamic Calendar date 25-03-1341 to JDC 2423373.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1341, 3, 25));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1341, 3, 25));
 
         checkJDC(2423373.5, jdc);
     });
 
     it('convert the Islamic Calendar date 20-07-1420 to JDC 2451481.5', () => {
-        const jdc = islamicToJDC(new CalendarDate(1420, 7, 20));
+        const jdc = JDNConvertibleConversionModule.islamicToJDC(new CalendarDate(1420, 7, 20));
 
         checkJDC(2451481.5, jdc);
     });
@@ -589,109 +571,109 @@ describe('Islamic to JDC', () => {
 describe('Islamic to JDN', () => {
 
     it('convert the Islamic Calendar date 17-03-1439 to JDN 2458094', () => {
-        const jdn = islamicToJDN(new CalendarDate(1439, 3, 17));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1439, 3, 17));
 
         checkJDN(2458094, jdn);
     });
 
     it('convert the Islamic Calendar date 01-01-1421 to JDN 2451641', () => {
-        const jdn = islamicToJDN(new CalendarDate(1421, 1, 1));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1421, 1, 1));
 
         checkJDN(2451641, jdn);
     });
 
     it('convert the Islamic Calendar date 29-12-0000 to JDN 1948439', () => {
-        const jdn = islamicToJDN(new CalendarDate(0, 12, 29));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(0, 12, 29));
 
         checkJDN(1948439, jdn);
     });
 
     it('convert the Islamic Calendar date 01-01-0001 to JDN 1948440', () => {
-        const jdn = islamicToJDN(new CalendarDate(1, 1, 1));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1, 1, 1));
 
         checkJDN(1948440, jdn);
     });
 
     it('convert the Islamic Calendar date 25-01-0104 to JDN 1984964', () => {
-        const jdn = islamicToJDN(new CalendarDate(104, 1, 25));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(104, 1, 25));
 
         checkJDN(1984964, jdn);
     });
 
     it('convert the Islamic Calendar date 20-02-0207 to JDN 2021489', () => {
-        const jdn = islamicToJDN(new CalendarDate(207, 2, 20));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(207, 2, 20));
 
         checkJDN(2021489, jdn);
     });
 
     it('convert the Islamic Calendar date 18-04-0310 to JDN 2058045', () => {
-        const jdn = islamicToJDN(new CalendarDate(310, 4, 18));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(310, 4, 18));
 
         checkJDN(2058045, jdn);
     });
 
     it('convert the Islamic Calendar date 15-06-0413 to JDN 2094601', () => {
-        const jdn = islamicToJDN(new CalendarDate(413, 6, 15));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(413, 6, 15));
 
         checkJDN(2094601, jdn);
     });
 
     it('convert the Islamic Calendar date 09-06-0516 to JDN 2131095', () => {
-        const jdn = islamicToJDN(new CalendarDate(516, 6, 9));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(516, 6, 9));
 
         checkJDN(2131095, jdn);
     });
 
     it('convert the Islamic Calendar date 28-05-0619 to JDN 2167584', () => {
-        const jdn = islamicToJDN(new CalendarDate(619, 5, 28));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(619, 5, 28));
 
         checkJDN(2167584, jdn);
     });
 
     it('convert the Islamic Calendar date 24-06-0722 to JDN 2204109', () => {
-        const jdn = islamicToJDN(new CalendarDate(722, 6, 24));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(722, 6, 24));
 
         checkJDN(2204109, jdn);
     });
 
     it('convert the Islamic Calendar date 08-08-0825 to JDN 2240652', () => {
-        const jdn = islamicToJDN(new CalendarDate(825, 8, 8));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(825, 8, 8));
 
         checkJDN(2240652, jdn);
     });
 
     it('convert the Islamic Calendar date 01-09-0928 to JDN 2277174', () => {
-        const jdn = islamicToJDN(new CalendarDate(928, 9, 1));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(928, 9, 1));
 
         checkJDN(2277174, jdn);
     });
 
     it('convert the Islamic Calendar date 08-10-1031 to JDN 2313711', () => {
-        const jdn = islamicToJDN(new CalendarDate(1031, 10, 8));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1031, 10, 8));
 
         checkJDN(2313711, jdn);
     });
 
     it('convert the Islamic Calendar date 27-11-1134 to JDN 2350258', () => {
-        const jdn = islamicToJDN(new CalendarDate(1134, 11, 27));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1134, 11, 27));
 
         checkJDN(2350258, jdn);
     });
 
     it('convert the Islamic Calendar date 29-12-1237 to JDN 2386790', () => {
-        const jdn = islamicToJDN(new CalendarDate(1237, 12, 29));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1237, 12, 29));
 
         checkJDN(2386790, jdn);
     });
 
     it('convert the Islamic Calendar date 25-03-1341 to JDN 2423374', () => {
-        const jdn = islamicToJDN(new CalendarDate(1341, 3, 25));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1341, 3, 25));
 
         checkJDN(2423374, jdn);
     });
 
     it('convert the Islamic Calendar date 20-07-1420 to JDN 2451482', () => {
-        const jdn = islamicToJDN(new CalendarDate(1420, 7, 20));
+        const jdn = JDNConvertibleConversionModule.islamicToJDN(new CalendarDate(1420, 7, 20));
 
         checkJDN(2451482, jdn);
     });
@@ -701,16 +683,16 @@ describe('Islamic to JDN', () => {
 describe('JDC to Islamic', () => {
 
     it('convert the JDC 2458093.5 to the Islamic Calendar date 17-03-1439', () => {
-        const islamicCalendarDate = JDCToIslamic(2458093.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2458093.5);
 
         const expectedDate = new CalendarDate(1439, 3, 17);
 
         checkCalendarDate(expectedDate, islamicCalendarDate);
-        
+
     });
 
     it('convert the JDC 2458093.6 to the Islamic Calendar date 17-03-1439', () => {
-        const islamicCalendarDate = JDCToIslamic(2458093.6);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2458093.6);
 
         const expectedDate = new CalendarDate(1439, 3, 17, undefined, 0.1);
 
@@ -729,7 +711,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2448481.5 to the Islamic Calendar date 02-02-1412', () => {
-        const islamicCalendarDate = JDCToIslamic(2448481.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2448481.5);
 
         const expectedDate = new CalendarDate(1412, 2, 2);
 
@@ -737,7 +719,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 1948438.5 to the Islamic Calendar date 29-12-0000', () => {
-        const islamicCalendarDate = JDCToIslamic(1948438.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(1948438.5);
 
         const expectedDate = new CalendarDate(0, 12, 29);
 
@@ -745,7 +727,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 1948439.5 to the Islamic Calendar date 01-01-0001', () => {
-        const islamicCalendarDate = JDCToIslamic(1948439.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(1948439.5);
 
         const expectedDate = new CalendarDate(1, 1, 1);
 
@@ -753,7 +735,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 1984963.5 to the Islamic Calendar date 25-01-0104', () => {
-        const islamicCalendarDate = JDCToIslamic(1984963.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(1984963.5);
 
         const expectedDate = new CalendarDate(104, 1, 25);
 
@@ -761,7 +743,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2021488.5 to the Islamic Calendar date 20-02-0207', () => {
-        const islamicCalendarDate = JDCToIslamic(2021488.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2021488.5);
 
         const expectedDate = new CalendarDate(207, 2, 20);
 
@@ -769,7 +751,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2058044.5 to the Islamic Calendar date 18-04-0310', () => {
-        const islamicCalendarDate = JDCToIslamic(2058044.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2058044.5);
 
         const expectedDate = new CalendarDate(310, 4, 18);
 
@@ -777,7 +759,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2094600.5 to the Islamic Calendar date 15-06-0413', () => {
-        const islamicCalendarDate = JDCToIslamic(2094600.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2094600.5);
 
         const expectedDate = new CalendarDate(413, 6, 15);
 
@@ -785,7 +767,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2131094.5 to the Islamic Calendar date 09-06-0516', () => {
-        const islamicCalendarDate = JDCToIslamic(2131094.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2131094.5);
 
         const expectedDate = new CalendarDate(516, 6, 9);
 
@@ -793,7 +775,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2167583.5 to the Islamic Calendar date 28-05-0619', () => {
-        const islamicCalendarDate = JDCToIslamic(2167583.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2167583.5);
 
         const expectedDate = new CalendarDate(619, 5, 28);
 
@@ -801,7 +783,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2204108.5 to the Islamic Calendar date 24-06-0722', () => {
-        const islamicCalendarDate = JDCToIslamic(2204108.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2204108.5);
 
         const expectedDate = new CalendarDate(722, 6, 24);
 
@@ -809,7 +791,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2240651.5 to the Islamic Calendar date 08-08-0825', () => {
-        const islamicCalendarDate = JDCToIslamic(2240651.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2240651.5);
 
         const expectedDate = new CalendarDate(825, 8, 8);
 
@@ -817,7 +799,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2277173.5 to the Islamic Calendar date 01-09-0928', () => {
-        const islamicCalendarDate = JDCToIslamic(2277173.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2277173.5);
 
         const expectedDate = new CalendarDate(928, 9, 1);
 
@@ -825,7 +807,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2313710.5 to the Islamic Calendar date 08-10-1031', () => {
-        const islamicCalendarDate = JDCToIslamic(2313710.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2313710.5);
 
         const expectedDate = new CalendarDate(1031, 10, 8);
 
@@ -833,7 +815,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2350257.5 to the Islamic Calendar date 27-11-1134', () => {
-        const islamicCalendarDate = JDCToIslamic(2350257.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2350257.5);
 
         const expectedDate = new CalendarDate(1134, 11, 27);
 
@@ -841,7 +823,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2386789.5 to the Islamic Calendar date 29-12-1237', () => {
-        const islamicCalendarDate = JDCToIslamic(2386789.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2386789.5);
 
         const expectedDate = new CalendarDate(1237, 12, 29);
 
@@ -849,7 +831,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2423373.5 to the Islamic Calendar date 25-03-1341', () => {
-        const islamicCalendarDate = JDCToIslamic(2423373.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2423373.5);
 
         const expectedDate = new CalendarDate(1341, 3, 25);
 
@@ -857,7 +839,7 @@ describe('JDC to Islamic', () => {
     });
 
     it('convert the JDC 2451481.5 to the Islamic Calendar date 20-07-1420', () => {
-        const islamicCalendarDate = JDCToIslamic(2451481.5);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDCToIslamic(2451481.5);
 
         const expectedDate = new CalendarDate(1420, 7, 20);
 
@@ -869,7 +851,7 @@ describe('JDC to Islamic', () => {
 describe('JDN to Islamic', () => {
 
     it('convert the JDN 2458094 to the Islamic Calendar date 17-03-1439', () => {
-        const islamicCalendarDate = JDNToIslamic(2458094);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2458094);
 
         const expectedDate = new CalendarDate(1439, 3, 17);
 
@@ -877,7 +859,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 1948439 to the Islamic Calendar date 29-12-0000', () => {
-        const islamicCalendarDate = JDNToIslamic(1948439);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(1948439);
 
         const expectedDate = new CalendarDate(0, 12, 29);
 
@@ -885,7 +867,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 1948440 to the Islamic Calendar date 01-01-0001', () => {
-        const islamicCalendarDate = JDNToIslamic(1948440);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(1948440);
 
         const expectedDate = new CalendarDate(1, 1, 1);
 
@@ -893,7 +875,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 1984964 to the Islamic Calendar date 25-01-0104', () => {
-        const islamicCalendarDate = JDNToIslamic(1984964);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(1984964);
 
         const expectedDate = new CalendarDate(104, 1, 25);
 
@@ -901,7 +883,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2021489 to the Islamic Calendar date 20-02-0207', () => {
-        const islamicCalendarDate = JDNToIslamic(2021489);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2021489);
 
         const expectedDate = new CalendarDate(207, 2, 20);
 
@@ -909,7 +891,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2058045 to the Islamic Calendar date 18-04-0310', () => {
-        const islamicCalendarDate = JDNToIslamic(2058045);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2058045);
 
         const expectedDate = new CalendarDate(310, 4, 18);
 
@@ -917,7 +899,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2094601 to the Islamic Calendar date 15-06-0413', () => {
-        const islamicCalendarDate = JDNToIslamic(2094601);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2094601);
 
         const expectedDate = new CalendarDate(413, 6, 15);
 
@@ -925,7 +907,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2131095 to the Islamic Calendar date 09-06-0516', () => {
-        const islamicCalendarDate = JDNToIslamic(2131095);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2131095);
 
         const expectedDate = new CalendarDate(516, 6, 9);
 
@@ -933,7 +915,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2167584 to the Islamic Calendar date 28-05-0619', () => {
-        const islamicCalendarDate = JDNToIslamic(2167584);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2167584);
 
         const expectedDate = new CalendarDate(619, 5, 28);
 
@@ -941,7 +923,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2204109 to the Islamic Calendar date 24-06-0722', () => {
-        const islamicCalendarDate = JDNToIslamic(2204109);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2204109);
 
         const expectedDate = new CalendarDate(722, 6, 24);
 
@@ -949,7 +931,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2240652 to the Islamic Calendar date 08-08-0825', () => {
-        const islamicCalendarDate = JDNToIslamic(2240652);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2240652);
 
         const expectedDate = new CalendarDate(825, 8, 8);
 
@@ -957,7 +939,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2277174 to the Islamic Calendar date 01-09-0928', () => {
-        const islamicCalendarDate = JDNToIslamic(2277174);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2277174);
 
         const expectedDate = new CalendarDate(928, 9, 1);
 
@@ -965,7 +947,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2313711 to the Islamic Calendar date 08-10-1031', () => {
-        const islamicCalendarDate = JDNToIslamic(2313711);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2313711);
 
         const expectedDate = new CalendarDate(1031, 10, 8);
 
@@ -973,7 +955,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2350258 to the Islamic Calendar date 27-11-1134', () => {
-        const islamicCalendarDate = JDNToIslamic(2350258);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2350258);
 
         const expectedDate = new CalendarDate(1134, 11, 27);
 
@@ -981,7 +963,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2386790 to the Islamic Calendar date 29-12-1237', () => {
-        const islamicCalendarDate = JDNToIslamic(2386790);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2386790);
 
         const expectedDate = new CalendarDate(1237, 12, 29);
 
@@ -989,7 +971,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2423374 to the Islamic Calendar date 25-03-1341', () => {
-        const islamicCalendarDate = JDNToIslamic(2423374);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2423374);
 
         const expectedDate = new CalendarDate(1341, 3, 25);
 
@@ -997,7 +979,7 @@ describe('JDN to Islamic', () => {
     });
 
     it('convert the JDN 2451482 to the Islamic Calendar date 20-07-1420', () => {
-        const islamicCalendarDate = JDNToIslamic(2451482);
+        const islamicCalendarDate = JDNConvertibleConversionModule.JDNToIslamic(2451482);
 
         const expectedDate = new CalendarDate(1420, 7, 20);
 
@@ -1015,13 +997,13 @@ describe('JDN conversions to Julian calendar and back', () => {
     it('convert the Julian Calendar date 2017-11-23 to JDN', () => {
 
         const julianCalendarDate: CalendarDate = new CalendarDate(2017, 11, 23);
-        const jdn = julianToJDN(julianCalendarDate);
+        const jdn = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(2458094, jdn);
     });
 
     it('convert the JDN 2458094 back to the Julian Calendar date 23-11-2017', () => {
-        const julianCalendarDate = JDNToJulian(2458094);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2458094);
 
         const expectedDate = new CalendarDate(2017, 11, 23);
 
@@ -1031,13 +1013,13 @@ describe('JDN conversions to Julian calendar and back', () => {
     it('convert the Julian Calendar date 1582-10-15 to JDN', () => {
 
         const julianCalendarDate: CalendarDate = new CalendarDate(1582, 10, 15);
-        const jdn = julianToJDN(julianCalendarDate);
+        const jdn = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(2299171, jdn);
     });
 
     it('convert the JDN 2299171 back to the Julian Calendar date 15-10-1582', () => {
-        const julianCalendarDate = JDNToJulian(2299171);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(2299171);
 
         const expectedDate = new CalendarDate(1582, 10, 15);
 
@@ -1047,13 +1029,13 @@ describe('JDN conversions to Julian calendar and back', () => {
     it('convert the Julian Calendar date (-1000)-01-01 to JDN', () => {
 
         const julianCalendarDate: CalendarDate = new CalendarDate(-1000, 1, 1);
-        const jdn = julianToJDN(julianCalendarDate);
+        const jdn = JDNConvertibleConversionModule.julianToJDN(julianCalendarDate);
 
         checkJDN(1355808, jdn);
     });
 
     it('convert the JDN 1355808 back to the Julian Calendar date 01-01-(-1000)', () => {
-        const julianCalendarDate = JDNToJulian(1355808);
+        const julianCalendarDate = JDNConvertibleConversionModule.JDNToJulian(1355808);
 
         const expectedDate = new CalendarDate(-1000, 1, 1);
 
@@ -2164,14 +2146,14 @@ describe('Create a JDNPeriod', () => {
     it('attempt to create a JDN with invalid args: non integers', () => {
 
         assert.throws(
-                () => {
-                    new JDNPeriod(1.1, 2)
-                },
-                function (err: Error) {
-                    if ((err instanceof Error) && err.message === 'JDNs are expected to be integers') {
-                        return true;
-                    }
+            () => {
+                new JDNPeriod(1.1, 2)
+            },
+            function (err: Error) {
+                if ((err instanceof Error) && err.message === 'JDNs are expected to be integers') {
+                    return true;
                 }
+            }
         );
 
     });
@@ -2179,15 +2161,15 @@ describe('Create a JDNPeriod', () => {
     it('attempt to create a JDN with invalid args: end greater than start', () => {
 
         assert.throws(
-                () => {
-                    new JDNPeriod(2, 1)
-                },
-                function (err: Error) {
+            () => {
+                new JDNPeriod(2, 1)
+            },
+            function (err: Error) {
 
-                    if ((err instanceof Error) && err.message === 'start of a JDNPeriod must not be greater than its end') {
-                        return true;
-                    }
+                if ((err instanceof Error) && err.message === 'start of a JDNPeriod must not be greater than its end') {
+                    return true;
                 }
+            }
         );
 
     });
@@ -2204,7 +2186,7 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
     it('create the JDN for the Julian calendar date 15-03-44 BCE when Caesar was murdered and convert it to Gregorian', () => {
 
         // assassination of Caesar: Julian calendar date 15-03-44 BCE
-        const jdn = julianToJDN(new CalendarDate(-43, 3, 15));
+        const jdn = JDNConvertibleConversionModule.julianToJDN(new CalendarDate(-43, 3, 15));
 
         checkJDN(1705426, jdn);
 
@@ -2559,15 +2541,15 @@ describe('For Julian and Gregorian calendar: Create a BCE date', () => {
 describe('Determine day of week from JDC', () => {
 
     it('Test for day of the week from JDC 2434923.5 to 3 (Wednesday)', () => {
-        assert.strictEqual(dayOfWeekFromJDC(2434923.5), 3);
+        assert.strictEqual(JDNConvertibleConversionModule.dayOfWeekFromJDC(2434923.5), 3);
     });
 
     it('Test for day of the week from JDC 2434924.0 to 3 (Wednesday)', () => {
-        assert.strictEqual(dayOfWeekFromJDC(2434924.0), 3);
+        assert.strictEqual(JDNConvertibleConversionModule.dayOfWeekFromJDC(2434924.0), 3);
     });
 
     it('Test for day of the week from JDC 2434924.4999 to 3 (Wednesday)', () => {
-        assert.strictEqual(dayOfWeekFromJDC(2434924.4999), 3);
+        assert.strictEqual(JDNConvertibleConversionModule.dayOfWeekFromJDC(2434924.4999), 3);
     });
 });
 

--- a/test/names.ts
+++ b/test/names.ts
@@ -18,7 +18,7 @@
  * License along with JDNConvertibleCalendar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {JDNConvertibleCalendarNames} from '../src';
+import { JDNConvertibleCalendarNames } from '../src/JDNCalendarNames';
 
 let assert = require('assert');
 

--- a/test/names.ts
+++ b/test/names.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
+ * Copyright © 2020 Lukas Rosenthaler, Rita Gautschy, Benjamin Geer, Ivan Subotic,
  * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
  *
  * This file is part of JDNConvertibleCalendar.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs",
+    "module": "es6",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
     "baseUrl": "./",
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "types": [
+      "mocha",
+      "@types/node"
+    ]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
resolves [DSP-790](https://dasch.myjetbrains.com/youtrack/issue/DSP-790)

This PR changes the lib's build options so it is built as an es6 module (before "commonjs" was used). This is necessary because Angular 10 shows warnings for libs built with "commonjs".

- mocha with esm: https://stackoverflow.com/questions/46487307/is-it-possible-to-use-es6-modules-in-mocha-tests/46487904
- mocha declarations: https://stackoverflow.com/questions/39816482/how-to-import-describe-and-it-from-mocha-in-typescript